### PR TITLE
set timeout in FetchDocumentService to 30 seconds

### DIFF
--- a/src/Core/Api/Services/FetchDocumentService.php
+++ b/src/Core/Api/Services/FetchDocumentService.php
@@ -47,11 +47,11 @@ class FetchDocumentService extends APIService implements FetchDocumentContract
           ]
         );
       }
-      // FIXME: set timeout(s) - we have seen this timeout after 10 seconds, leading to errors.
+      
       curl_setopt($ch, CURLOPT_URL, $url);
       curl_setopt($ch, CURLOPT_HEADER, 0);
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-      curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+      curl_setopt($ch, CURLOPT_TIMEOUT, 30);
       $output = curl_exec($ch);
       if (curl_errno($ch)) {
         $this->loggerContract


### PR DESCRIPTION
Increases the timeout for the cURL client in `FetchDocumentService` from 10 seconds to 30 seconds.
This lowers the chance of a timeout event while getting labels and/or packing slips.

This is a provisional step in resolving https://github.com/wayfair-contribs/plentymarkets-plugin/issues/10