### PR TITLE
bump minimist to 1.2.5

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -1142,6 +1142,12 @@
 				}
 			}
 		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"optional": true
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -3061,15 +3067,36 @@
 			}
 		},
 		"extract-zip": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
 			"optional": true,
 			"requires": {
-				"concat-stream": "1.6.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1",
-				"yauzl": "2.4.1"
+				"concat-stream": "^1.6.2",
+				"debug": "^2.6.9",
+				"mkdirp": "^0.5.4",
+				"yauzl": "^2.10.0"
+			},
+			"dependencies": {
+				"fd-slicer": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+					"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+					"optional": true,
+					"requires": {
+						"pend": "~1.2.0"
+					}
+				},
+				"yauzl": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+					"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+					"optional": true,
+					"requires": {
+						"buffer-crc32": "~0.2.3",
+						"fd-slicer": "~1.1.0"
+					}
+				}
 			}
 		},
 		"extsprintf": {
@@ -3116,15 +3143,6 @@
 			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
-			}
-		},
-		"fd-slicer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-			"optional": true,
-			"requires": {
-				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -5847,9 +5865,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mississippi": {
 			"version": "2.0.0",
@@ -5907,11 +5925,11 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"moment": {
@@ -6439,6 +6457,12 @@
 				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				},
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -10938,15 +10962,6 @@
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 					"dev": true
 				}
-			}
-		},
-		"yauzl": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-			"optional": true,
-			"requires": {
-				"fd-slicer": "~1.0.1"
 			}
 		},
 		"zone.js": {


### PR DESCRIPTION
Remove security alert about updating `minimist` to 0.2.1 or later, by rebuilding the node packages after some targeted removals.