### PR TITLE
 Adding plugin version to logs

### DIFF
--- a/src/Core/Helpers/AbstractConfigHelper.php
+++ b/src/Core/Helpers/AbstractConfigHelper.php
@@ -33,21 +33,21 @@ abstract class AbstractConfigHelper {
   const INVENTORY_ITEMS_PER_PAGE = 500;
 
   /**
-   * Retrieve the configuration client id for the global client
+   * Retrieve the configured client ID for connections to Wayfair's secure APIs
    *
    * @return mixed
    */
   abstract public function getClientId();
 
   /**
-   * Retrieve the configuration client secret for the global client
+   * Retrieve the configured client secret for connections to Wayfair's secure APIs
+   *
    * @return mixed
    */
   abstract public function getClientSecret();
 
   /**
-   * Checks if an item already exists in cache and returns the key,
-   * if the item does not exists in cache adds item to cache
+   * Returns an Order Referrer Key
    *
    * @return int
    */
@@ -59,7 +59,7 @@ abstract class AbstractConfigHelper {
   abstract public function getStockBufferValue();
 
   /**
-   * Retrieve the configuration values for setting up a test environment
+   * Checks if the plugin is configured to use the test / dryRun mode when communicating with the Wayfair APIs
    *
    * @return string
    */

--- a/src/Core/Helpers/AbstractConfigHelper.php
+++ b/src/Core/Helpers/AbstractConfigHelper.php
@@ -33,16 +33,22 @@ abstract class AbstractConfigHelper {
   const INVENTORY_ITEMS_PER_PAGE = 500;
 
   /**
+   * Retrieve the configuration client id for the global client
+   *
    * @return mixed
    */
   abstract public function getClientId();
 
   /**
+   * Retrieve the configuration client secret for the global client
    * @return mixed
    */
   abstract public function getClientSecret();
 
   /**
+   * Checks if an item already exists in cache and returns the key,
+   * if the item does not exists in cache adds item to cache
+   *
    * @return int
    */
   abstract public function getOrderReferrerValue(): int;
@@ -53,6 +59,8 @@ abstract class AbstractConfigHelper {
   abstract public function getStockBufferValue();
 
   /**
+   * Retrieve the configuration values for setting up a test environment
+   *
    * @return string
    */
   abstract public function getDryRun(): string;
@@ -63,12 +71,15 @@ abstract class AbstractConfigHelper {
   abstract public function isAllItemsActive(): bool;
 
   /**
+   * Check if boot is completed
    *
    * @return bool
    */
   abstract public function hasBooted(): bool;
 
   /**
+   * Retrieves the current Wayfair plugin version
+   *
    * @return string
    */
   abstract public function getPluginVersion(): string;

--- a/src/Core/Helpers/AbstractConfigHelper.php
+++ b/src/Core/Helpers/AbstractConfigHelper.php
@@ -47,7 +47,7 @@ abstract class AbstractConfigHelper {
   abstract public function getClientSecret();
 
   /**
-   * Returns an Order Referrer Key
+   * Returns an Order Referrer value
    *
    * @return int
    */

--- a/src/Core/Helpers/AbstractConfigHelper.php
+++ b/src/Core/Helpers/AbstractConfigHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2019 Wayfair LLC - All rights reserved
+ * @copyright 2020 Wayfair LLC - All rights reserved
  */
 
 namespace Wayfair\Core\Helpers;
@@ -47,7 +47,7 @@ abstract class AbstractConfigHelper {
   abstract public function getClientSecret();
 
   /**
-   * Returns an Order Referrer value
+   * Returns the PlentyMarkets identifier for Wayfair's Order Referrer value
    *
    * @return int
    */

--- a/src/Core/Helpers/AbstractConfigHelper.php
+++ b/src/Core/Helpers/AbstractConfigHelper.php
@@ -68,4 +68,9 @@ abstract class AbstractConfigHelper {
    */
   abstract public function hasBooted(): bool;
 
+  /**
+   * @return string
+   */
+  abstract public function getPluginVersion(): string;
+
 }

--- a/src/Helpers/ConfigHelper.php
+++ b/src/Helpers/ConfigHelper.php
@@ -113,7 +113,7 @@ class ConfigHelper extends AbstractConfigHelper {
   /**
    * @return string
    */
-  public function getPluginVersion() {
+  public function getPluginVersion(): string {
     $pluginRepo = pluginApp(PluginRepositoryContract::class);
     $plugin = $pluginRepo->getPluginByName(AbstractConfigHelper::PLUGIN_NAME);
     $plugin = $pluginRepo->decoratePlugin($plugin);

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -116,6 +116,8 @@ class LoggingService implements LoggerContract {
   }
 
   /**
+   * Maps data from the PlentyMarket designed associative array to values of an array to be used by our different log methods
+   *
    * @param $loggingInfo
    *
    * @return array

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -9,6 +9,7 @@ use Plenty\Plugin\Log\Loggable;
 
 use Wayfair\Core\Contracts\LoggerContract;
 use Wayfair\Core\Helpers\AbstractConfigHelper;
+use Wayfair\Helpers\ConfigHelper;
 
 class LoggingService implements LoggerContract {
   use Loggable;
@@ -18,8 +19,15 @@ class LoggingService implements LoggerContract {
   const WARNING = 'WARNING';
   const ERROR = 'ERROR';
 
+  /**
+   * Stores the version of the plugin
+   * @var string $version
+   */
+  public $version;
+
   public function __construct() {
-   
+    $configHelper = new ConfigHelper();
+   $this->$version = $configHelper->getPluginVersion();
   }
 
   /**
@@ -121,7 +129,7 @@ class LoggingService implements LoggerContract {
    * Checks if it is alright to log at a level lower than ERROR.
    * Logging at levels such as INFO and DEBUG prior to the end of the "boot" period
    * Causes issues.
-   * 
+   *
    * See https://forum.plentymarkets.com/t/wayfair-log-levels-info-and-debug-not-working-for-loggable-module/581320/22
    *
    * @return boolean

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -25,9 +25,12 @@ class LoggingService implements LoggerContract {
    */
   public $version;
 
+  /**
+   * Undocumented function
+   */
   public function __construct() {
-    $configHelper = new ConfigHelper();
-   $this->$version = $configHelper->getPluginVersion();
+    $configHelper = pluginApp(AbstractConfigHelper::class);
+    $this->$version = $configHelper->getPluginVersion();
   }
 
   /**
@@ -121,6 +124,7 @@ class LoggingService implements LoggerContract {
     $method = $loggingInfo['method'] ?? null;
     $referenceType = $loggingInfo['referenceType'] ?? null;
     $referenceValue = (int) $loggingInfo['referenceValue'] ?? null;
+    $additionalInfo['wayfairPluginVersion'] = $this->version;
 
     return array($additionalInfo, $method, $referenceType, $referenceValue);
   }

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -30,7 +30,7 @@ class LoggingService implements LoggerContract {
    */
   public function __construct() {
     $configHelper = pluginApp(AbstractConfigHelper::class);
-    $this->$version = $configHelper->getPluginVersion();
+    $this->version = $configHelper->getPluginVersion();
   }
 
   /**

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -9,7 +9,6 @@ use Plenty\Plugin\Log\Loggable;
 
 use Wayfair\Core\Contracts\LoggerContract;
 use Wayfair\Core\Helpers\AbstractConfigHelper;
-use Wayfair\Helpers\ConfigHelper;
 
 class LoggingService implements LoggerContract {
   use Loggable;

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -17,15 +17,17 @@ class LoggingService implements LoggerContract {
   const INFO = 'INFO';
   const WARNING = 'WARNING';
   const ERROR = 'ERROR';
+  const WAYFAIR_PLUGIN_VERSION = 'Wayfair Plugin Version';
 
   /**
    * Stores the version of the plugin
+   *
    * @var string $version
    */
   public $version;
 
   /**
-   * Undocumented function
+   * Initialize a logging service object
    */
   public function __construct() {
     $configHelper = pluginApp(AbstractConfigHelper::class);
@@ -123,7 +125,7 @@ class LoggingService implements LoggerContract {
     $method = $loggingInfo['method'] ?? null;
     $referenceType = $loggingInfo['referenceType'] ?? null;
     $referenceValue = (int) $loggingInfo['referenceValue'] ?? null;
-    $additionalInfo['wayfairPluginVersion'] = $this->version;
+    $additionalInfo[self::WAYFAIR_PLUGIN_VERSION] = $this->version;
 
     return array($additionalInfo, $method, $referenceType, $referenceValue);
   }

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -116,7 +116,7 @@ class LoggingService implements LoggerContract {
   }
 
   /**
-   * Maps data from the PlentyMarket designed associative array to values of an array to be used by our different log methods
+   * Maps data from the he associative array that Wayfair provides to the PlentyMarkets logging API's inputs
    *
    * @param $loggingInfo
    *


### PR DESCRIPTION
To make it easier on developer to address bug fixes made by suppliers Wayfair plugin version has been added to the PlentyMarkets logs generated by the Wayfair plugin.