### PR TITLE
remove chars at beginning of English user guide

### DIFF
--- a/meta/documents/user_guide_en.md
+++ b/meta/documents/user_guide_en.md
@@ -1,4 +1,4 @@
-﻿﻿# Wayfair plugin user guide
+# Wayfair plugin user guide
 <div class="container-toc"></div>
 
 ## 1. Registering with Wayfair


### PR DESCRIPTION
Weird characters at the beginning of the English user guide were ruining the Markdown formatting