### PR TITLE
Blocker: APIService module does not compile

### DIFF
--- a/src/Core/Api/APIService.php
+++ b/src/Core/Api/APIService.php
@@ -16,7 +16,7 @@ use Wayfair\Http\WayfairResponse;
 
 class APIService {
 
-  const LOK_KEY_API_SERVICE = 'apiService';
+  const LOG_KEY_API_SERVICE = 'apiService';
 
   /**
    * @var AuthenticationContract


### PR DESCRIPTION
- change constant from `LOK_KEY_API_SERVICE` to `LOG_KEY_API_SERVICE`