### PR TITLE
make all inventory saves use DIFFERENTIAL for feedKind

### DIFF
--- a/src/Core/Api/Services/InventoryService.php
+++ b/src/Core/Api/Services/InventoryService.php
@@ -108,7 +108,7 @@ class InventoryService extends APIService
       . 'inventory {'
       . 'save('
       . 'inventory: $inventory,'
-      . 'feedKind: ' . ($fullInventory ? 'TRUE_UP' : 'DIFFERENTIAL') . ','
+      . 'feedKind: DIFFERENTIAL,'
       . 'dryRun: ' . $configHelper->getDryRun()
       . ') {'
       . 'id,'


### PR DESCRIPTION
As we need to do "chunked" inventory feeds, even for "full inventory," we cannot use `TRUE_UP` for the `feedKind` as `TRUE_UP` implies that it contains ALL inventory for all items.
This change will force all inventory feeds to have the `DIFFERENTIAL` value for `feedKind`.