### PR TITLE
remove try catch when Fetching orders

### DIFF
--- a/src/Core/Api/Services/FetchOrderService.php
+++ b/src/Core/Api/Services/FetchOrderService.php
@@ -23,11 +23,8 @@ class FetchOrderService extends APIService {
    */
   public function fetch(int $circle): array {
     $query = $this->getQuery($circle);
-    try {
-      $response = $this->query($query);
-    } catch (\Exception $e) {
-      throw new GraphQLQueryException("RequestException exception for fetching purchase orders.", $e->getMessage());
-    }
+
+    $response = $this->query($query);
 
     if (!isset($response))
     {


### PR DESCRIPTION
Fetch Order Service was eating Exceptions and had a syntax error in the code where it did so.