### PR TITLE
remove junk code from ShipmentRegisterService

### DIFF
--- a/src/Services/ShipmentRegisterService.php
+++ b/src/Services/ShipmentRegisterService.php
@@ -153,10 +153,7 @@ class ShipmentRegisterService
    * @return bool
    */
   private function shipmentIsRegistered(
-    ShippingInformation $shippingInformation,
-    int $orderId,
-    string $poNumber,
-    ExternalLogs $externalLogs
+    ShippingInformation $shippingInformation
   ): bool {
     return $shippingInformation !== null
       && $shippingInformation->shippingServiceProvider === AbstractConfigHelper::PLUGIN_NAME
@@ -272,7 +269,7 @@ class ShipmentRegisterService
         try {
           $shippingInformation = $this->getOrderShippingInformation($orderId);
 
-          if ($this->shipmentIsRegistered($shippingInformation, $orderId, $poNumber, $externalLogs)) {
+          if ($this->shipmentIsRegistered($shippingInformation)) {
 
             // If order has already been registered with Wayfair, ignore and alert supplier.
             $registerResult[$orderId] =


### PR DESCRIPTION
* Remove member variable `registerResult` due to risky side-effects / race conditions
    * being used as a local variable in some contexts, as a member variable in others
    * was cleared out when calling some functions
    * (de)registration for one set of POs could impact (de)registration for other POs
* Remove unused member variable `warehouseSupplierRepository`
* Remove unneeded `WarehouseSupplierRegistry` import (as `warehouseSupplierRepository` was removed)