### PR TITLE
use Order contract to get properties

### DIFF
--- a/src/Services/OrderPropertyService.php
+++ b/src/Services/OrderPropertyService.php
@@ -131,6 +131,7 @@ class OrderPropertyService
 
   /**
    * Get all order properties by order id.
+   * NOTE: OrderPropertyRepositoryContract was retired in the plentymarkets backend in 2020
    *
    * @param int $orderId
    *
@@ -149,6 +150,7 @@ class OrderPropertyService
 
   /**
    * Get the value for an order's property
+   * NOTE: OrderPropertyRepositoryContract was retired in the plentymarkets backend in 2020
    *
    * @param integer $orderId
    * @param integer $propertyType

--- a/src/Services/OrderPropertyService.php
+++ b/src/Services/OrderPropertyService.php
@@ -62,7 +62,7 @@ class OrderPropertyService
     ShippingInformationRepositoryContract $shippingInformationRepositoryContract,
     LoggerContract $loggerContract
   ) {
-    $this->OrderRepositoryContract = $orderRepositoryContract;
+    $this->orderRepositoryContract = $orderRepositoryContract;
     $this->warehouseSupplierRepository = $warehouseSupplierRepository;
     $this->shippingInformationRepositoryContract = $shippingInformationRepositoryContract;
     $this->loggerContract = $loggerContract;

--- a/src/Services/OrderPropertyService.php
+++ b/src/Services/OrderPropertyService.php
@@ -147,8 +147,13 @@ class OrderPropertyService
 
     $props = $plentyOrder->properties;
 
-    if (isset($props) && is_array($props) && !empty($props))
+    if (isset($props) && !empty($props))
     {
+      if (!is_array($props))
+      {
+        throw new \Exception("Order properties are not an array. They are " . get_class($props));
+      }
+
       return $props;
     }
 

--- a/src/Services/OrderPropertyService.php
+++ b/src/Services/OrderPropertyService.php
@@ -145,7 +145,14 @@ class OrderPropertyService
       throw new \Exception("Order not found : " . (string)$orderId);
     }
 
-    return $plentyOrder->properties;
+    $props = $plentyOrder->properties;
+
+    if (isset($props) && is_array($props) && !empty($props))
+    {
+      return $props;
+    }
+
+    throw new \Exception("Order is missing properties: " . $orderId)
   }
 
   /**

--- a/src/Services/OrderPropertyService.php
+++ b/src/Services/OrderPropertyService.php
@@ -157,7 +157,7 @@ class OrderPropertyService
       return $props;
     }
 
-    throw new \Exception("Order is missing properties: " . $orderId)
+    throw new \Exception("Order is missing properties: " . $orderId);
   }
 
   /**

--- a/src/Services/SaveOrderDocumentService.php
+++ b/src/Services/SaveOrderDocumentService.php
@@ -172,15 +172,18 @@ class SaveOrderDocumentService
       throw new \Exception("Cannot check for Plentymarkets order - no PO Number provided.");
     }
 
-    $this->orderRepositoryContract->setFilters(['externalOrderId' => $poNumber]);
-    $orderList = $this->orderRepositoryContract->searchOrders();
+    $orderId = null;
 
-    if ($orderList->getTotalCount() >= 1) {
-      $result_item = $orderList->getResult();
+    $plentyOrder = $this->orderRepositoryContract->findOrderByExternalOrderId($poNumber);
 
-      if (isset($result_item) && array_key_exists(0, $result_item) && array_key_exists('id', $result_item[0])) {
-        return $result_item[0]['id'];
-      }
+    if (isset($plentyOrder))
+    {
+      $orderId = $plentyOrder->id;
+    }
+
+    if (isset($orderId))
+    {
+      return $orderId;
     }
 
     throw new \Exception('Plentymarkets Order does not exist for Wayfair poNumber: ' . $poNumber);

--- a/src/Services/ShipmentRegisterService.php
+++ b/src/Services/ShipmentRegisterService.php
@@ -443,7 +443,9 @@ class ShipmentRegisterService
                 'orderId' => $orderId,
                 'po' => $poNumber,
                 'amtTrackingNumbers' => $amtTrackingNumbers,
-                'amtPackages' => $amtPackages
+                'amtPackages' => $amtPackages,
+                'trackingNumbers' => $trackingNumbers,
+                'packages' => $packages
               ],
               'method' => __METHOD__
             ]);

--- a/src/Services/ShipmentRegisterService.php
+++ b/src/Services/ShipmentRegisterService.php
@@ -529,10 +529,14 @@ class ShipmentRegisterService
               ->info(
                 TranslationHelper::getLoggerKey(self::LOG_KEY_SAVED_SHIPMENT),
                 [
-                  'additionalInfo' => ['shipmentItems' => $shipmentItems],
+                  'additionalInfo' => [
+                    'orderId' => $orderId,
+                    'shipmentItems' => $shipmentItems,
+                    'poNumber' => $poNumber,
+                    'trackingNumber' => $trackingNumber,
+                    'shipmentNumber' => $shipmentNumber
+                  ],
                   'method' => __METHOD__,
-                  'referenceType' => 'poNumber',
-                  'referenceValue' => $poNumber
                 ]
               );
 


### PR DESCRIPTION
Repair bugs to enable Shipment Registration

- Remove usage of `OrderPropertyRepositoryContract`.
    - Per Plentymarkets:"You don’t get all properties of an order from the order property repository. Use the Order repository and access the properties on the Order."

    - See https://forum.plentymarkets.com/t/adding-shipping-information-to-an-order/598381/11

- Use `findOrderByExternalOrderId` instead of doing a manual search + browse of Orders (which was failing!)

- Add details to logs, to help @jathmel verify ASN behaviors