### PR TITLE
change log level for "amount of packages does not match amount of shipping labels" to debug

### DIFF
--- a/src/Services/ShipmentRegisterService.php
+++ b/src/Services/ShipmentRegisterService.php
@@ -435,10 +435,10 @@ class ShipmentRegisterService
           }
 
           if ($amtTrackingNumbers != $amtPackages) {
-            $externalLogs->addErrorLog('Amount of tracking numbers(' . $amtTrackingNumbers .
+            $externalLogs->addDebugLog('Amount of tracking numbers(' . $amtTrackingNumbers .
               ') does not match amount of packages (' . $amtPackages . ') PO:' . $poNumber);
 
-            $this->loggerContract->error(TranslationHelper::getLoggerKey(self::LOG_KEY_LABELS_SIZE_DOES_NOT_MATCH_PACKAGES_SIZE), [
+            $this->loggerContract->debug(TranslationHelper::getLoggerKey(self::LOG_KEY_LABELS_SIZE_DOES_NOT_MATCH_PACKAGES_SIZE), [
               'additionalInfo' => [
                 'orderId' => $orderId,
                 'po' => $poNumber,


### PR DESCRIPTION
It's okay to have one tracking number for multiple shipments on the same Order. Our logs should reflect that. This new log was introduced after the last official release.

(Checks are already in place for a lack of tracking number).