### PR TITLE
refactor the ENG user guide to link-out to github for all information

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Please enquire with Wayfair ERP Support <ERPSupport [at] wayfair.com> with any q
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [releases of this repository](https://github.com/wayfair/plentymarkets-plugin/releases).
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [releases of this repository](https://github.com/wayfair-contribs/plentymarkets-plugin/releases).
 
 ## Authors
 

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -1,11 +1,20 @@
 # Wayfair plugin: Initial Setup
 
 ## Prerequisites
+
+* [A Plentymarkets system](https://www.plentymarkets.co.uk).
+
+* Administrative rights on the Plentymarkets system where the Wayfair plugin will be used
+    - The Plentymarkets user's `Access` setting must be `Admin`
+    - The Plentymarkets user must be able to modify Plugin Sets
+
+* Active Wayfair supplier status
+    * A Wayfair Supplier ID is required
+    * [Information for prospective suppliers](https://partners.wayfair.com/d/onboarding/sell-on-wayfair)
+
 * [Wayfair API credentials](obtaining_credentials.md).
 
-* Administrative rights on the Plentymarkets system
-
-* [Installation](plugin_installation.md) of the Wayfair plugin - [view release notes](https://github.com/wayfair-contribs/plentymarkets-plugin/releases)
+* [Installation of the Wayfair plugin](plugin_installation.md).
 
 
 ## 1. Authorizing the Wayfair Plugin to access Wayfair interfaces
@@ -13,7 +22,7 @@ After the plugin is installed in your Plentymarkets Plugin Set, the plugin must 
 
 * **The authorization procedure must be performed for any Plugin Set that contains the Wayfair plugin**.
 * Copying a Plugin Set will copy the authorization information to the new plugin set.
-* An exported or imported Plugin set may include the authorization information.
+* An exported or imported Plugin Set may include the authorization information.
 
 The authorization steps are as follows:
 1. From the main Plentymarkets page, go to `Plugins` >> `Plugin set overview`
@@ -33,7 +42,7 @@ The authorization steps are as follows:
 7. Click the `Save` button in the toolbar above the settings
 
 ## 2. Activating the order referrer
-An order referrer in Plentymarkets denotes the sales channel on which an order was generated. To get the Plentymarkets system to properly import orders from the Wayfair API, the Wayfair order referrer must be activated:
+An order referrer in Plentymarkets identifies the sales channel on which an order was generated. To get the Plentymarkets system to properly import orders from the Wayfair API, the Wayfair order referrer must be activated:
 
 1. From the main Plentymarkets page, go to `Setup` >> `Orders` >> `Order referrer`.
 
@@ -50,7 +59,7 @@ In order to properly handle incoming orders from Wayfair, the Wayfair plugin mus
 If the Wayfair Supplier Part Numbers for your organization are to be reflected in an alternative field in your Plentymarkets Item Variations, change the value of [the `Item Mapping Method` setting](settings_guide.md#item-mapping-method) and update the Variations accordingly.
 
 ## 5. Making items available for sale on Wayfair
-Items that you want to sell on the Wayfair market must be considered active in Plentymarkets. The Plentymarkets user may also choose limit which Items are for sale on Wayfair. **Note that Inventory and ordered items are controlled at the `Variation` level.**
+Items that you want to sell on the Wayfair market must be considered active in Plentymarkets. The Plentymarkets user may also choose to limit which Items are for sale on Wayfair. **Note that Inventory and ordered items are controlled at the `Variation` level.**
 
 To ensure that an Item is available for sale, follow these instructions:
 
@@ -71,7 +80,7 @@ To ensure that an Item is available for sale, follow these instructions:
 
 ## 6. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
 
-In order to update the inventory data in Wayfair's system, you need to map the Warehouses in your Plentymarkets system to the Supplier IDs in Wayfair's system, on the [Warehouses](settings_guide.md#warehouses-page) page of the plugin's settings.
+In order to update the inventory data in Wayfair's system, you need to map the Warehouses in your Plentymarkets system to the Supplier IDs in Wayfair's system, on the [Warehouses](settings_guide.md#warehouses-page) page of [the plugin's settings](settings_guide.md).
 
 ## 7. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
 

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -7,6 +7,7 @@
 
 * [Installation](plugin_installation.md) of the Wayfair plugin - [view release notes](https://github.com/wayfair-contribs/plentymarkets-plugin/releases)
 
+
 ## 1. Authorizing the Wayfair Plugin to access Wayfair interfaces
 After the plugin is installed in your Plentymarkets system, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces:
 
@@ -155,3 +156,8 @@ If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings
 The final settings result should look similar to this:
 
 ![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
+
+## 9. Performing the first Inventory Synchronization
+Once everything has been set up, the it is time to start listing items for sale on Wayfair.
+
+Finalize the setup by initiating a full inventory synchronization on the [Full Inventory](settings_guide.md#full-inventory-page) page of the [Wayfair Market Settings](settings_guide.md)

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -44,12 +44,12 @@ An order referrer in Plentymarkets denotes the sales channel on which an order w
 ## 3. Setting up Plentymarkets for shipping through Wayfair
 To ensure proper integrations with Wayfair when shipping order items, follow the procedures outlined in  [the Wayfair Shipping instructions](wayfair_shipping.md).
 
-## 5. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
+## 4. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
 In order to properly handle incoming orders from Wayfair, the Wayfair plugin must match the Supplier Part Numbers in Wayfair's systems with a specific field of Item Variations in Plentymarkets. By default, the Wayfair plugin operates on the assumption that the `Variation Number` **(not to be confused with the Variation's ID)** of an Item's Variation in Plentymarkets will match the Wayfair Supplier Part Number.
 
 If the Wayfair Supplier Part Numbers for your organization are to be reflected in an alternative field in your Plentymarkets Item Variations, change the value of [the `Item Mapping Method` setting](settings_guide.md#item-mapping-method) and update the Variations accordingly.
 
-## 6. Making items available for sale on Wayfair
+## 5. Making items available for sale on Wayfair
 Items that you want to sell on the Wayfair market must be considered active in Plentymarkets. The Plentymarkets user may also choose limit which Items are for sale on Wayfair. **Note that Inventory and ordered items are controlled at the `Variation` level.**
 
 To ensure that an Item is available for sale, follow these instructions:
@@ -69,18 +69,18 @@ To ensure that an Item is available for sale, follow these instructions:
     3. Click the `Save` button next to the Variation `ID` (not the higher-up button for the Item).
 
 
-## 7. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
+## 6. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
 
 In order to update the inventory data in Wayfair's system, you need to map the Warehouses in your Plentymarkets system to the Supplier IDs in Wayfair's system, on the [Warehouses](settings_guide.md#warehouses-page) page of the plugin's settings.
 
-## 8. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
+## 7. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
 
-### 8.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
+### 7.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
 Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update the [Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
 
 If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.
 
-### 8.2 Creating an Event for Plentymarkets Orders that sends shipment information to Wayfair
+### 7.2 Creating an Event for Plentymarkets Orders that sends shipment information to Wayfair
 
 1. Click **Setup** in the top navigation bar then go to **Orders >> Events**
 ![Create Event](https://i.ibb.co/NjDtY05/asn-02.png "Create Event")
@@ -113,7 +113,7 @@ The final settings result should look similar to this:
 
 ![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
 
-## 9. Performing the first inventory synchronization
+## 8. Performing the first inventory synchronization
 Once everything has been set up, the it is time to start listing items for sale on Wayfair.
 
 Finalize the setup by initiating a full inventory synchronization on the [Full Inventory](settings_guide.md#full-inventory-page) page of the [Wayfair Market Settings](settings_guide.md).

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -141,13 +141,17 @@ If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings
 7.	You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a checkmark next to **Active**.
 
 8.  Click on **Add Filter**, and go to **Order >> Referrer** to add the referrer as a filter (see screenshot below)
+
 ![Event Referrer](https://i.ibb.co/TwKLvJ5/asn-03.png "Event Referrer")
 
 9.	In the **Filter** section, a box should appear with a list of all available Order referrers. Place a checkmark next to all **Wayfair** order referrers.
+
 ![Wayfair Referrer](https://i.ibb.co/yYpLp8q/asn-04.png "Wayfair Referrer")
 
 10. Click on **Add procedure**, and go to **Plugins >> Send Ship Confirmation (ASN) to Wayfair**. Click on **+ add**.
+
 ![Add Procedure](https://i.ibb.co/xfGrhFP/asn-05.png "Add Procedure")
 
 The final settings result should look similar to this:
+
 ![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -1,103 +1,47 @@
-## Authorizing the Wayfair Plugin to access Wayfair interfaces
-After the plugin is installed in your Plentymarkets system, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces.
+# Wayfair plugin: Initial Setup
 
-1. Go to **Plugins >> Plugin Overview**
+## Prerequisites
+* [Wayfair API credentials](obtaining_credentials.md).
 
-2. Select the plugin set that contains the Wayfair plugin
+* Administrative rights on the Plentymarkets system
 
-3. Click on the "Wayfair " name in the plugin set details
+* [Installation](plugin_installation.md) of the Wayfair plugin - [view release notes](https://github.com/wayfair-contribs/plentymarkets-plugin/releases)
 
-4. Go to **Configuration >> Global Settings**
+## 1. Authorizing the Wayfair Plugin to access Wayfair interfaces
+After the plugin is installed in your Plentymarkets system, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces:
 
-5. Enter the Client ID and Client Secret you received when creating the application in Extranet into the fields **Client ID** and **Client Secret**.
+1. From the main Plentymarkets page, go to `Plugins` >> `Plugin set overview`
 
-6. Change **Mode** to **Live**.
-7. **Save** the settings.
+2. Locate the Plugin Set that is linked to the client with which Wayfair will be used.
 
-## 4. Activating the order referrer
+3. Click on the `Edit` button for the desired Plugin set
 
-An order referrer indicates the sales channel on which an order was generated. You have to activate the Wayfair order referrer in order to link items, properties etc. with Wayfair.
+4. In the Wayfair row of the Plugin set, click on the `Settings` button.
 
-### Activating the order referrer for Wayfair:
+4. In the left-side menu, go to `Configuration` >> `Global Settings`.
 
-1. Go to **System >> Orders >> Order referrer**.
+5. In the `Supplier Settings` area, enter the `Client ID` and `Client Secret` values that correspond with your Wayfair API credentials
+
+6. Change the `Mode` setting to `Live` - see [information on `Test` mode](test_mode.md)
+
+7. Click the `Save` button in the toolbar above the settings
+
+## 2. Activating the order referrer
+An order referrer in Plentymarkets denotes the sales channel on which an order was generated. To get the Plentymarkets system to properly import orders from the Wayfair API, the Wayfair order referrer must be activated:
+
+1. From the main Plentymarkets page, go to `Setup` >> `Orders` >> `Order referrer`.
 
 2. Place a check mark next to the **Wayfair** order referrer.
 
 3. Click on **Save**.
 
-## 5. Making an item available for Wayfair.
+## 3. Creating a new shipping profile for shipping through Wayfair
+**TODO: when and why**
 
-Items that you want to sell on the Wayfair website have to be active and available for Wayfair. These settings are carried out in the **Item >> Edit item >> Open item>> Tab: Variation ID**. Please keep in mind that you have to carry out these settings for all the items that you wish to sell on Wayfair.
+**TODO: what comes with the plugin**
 
-### Setting the item availability for Wayfair:
+**TODO: what needs to be manually created - ???different for "Wayfair shipping" VS "Own account" shipping???**
 
-1. Go to **Item >> Edit Item** then click on the **Item ID** of the item that you wish to make available for Wayfair.
-
-2. You will be redirected to the **Settings** tab of the chosen item. In this tab, there is a section called **Availability**. Place a check mark next to the option **Active** in this section.
-
-3. Click on the tab **Availability**.
-
-4. Click in the selection field in the **Markets** section. A list with all available markets is displayed.
-
-5. Place a check mark next to the option **Wayfair**.
-
-6. Click on **Add**. The market is now added.
-
-7. Click on **Save**. The item is now available for Wayfair.
-
-### 6. Matching an incoming order with your items in Plentymarkets:
-In order to match an item in Wayfair's database, which is defined by the Supplier Part Number you have provided to Wayfair, with your items in Plentymarkets, you need to configure which Plentymarkets field the Wayfair Supplier Part Number should match with.
-
-To do so, follow the instructions below:
-
-1. Go to **Setup >> System >> Markets >> Wayfair >> Home**.
-
-2. Once the homepage of the plugin has loaded, click on **Settings**.
-
-3. Under **Item Mapping Method**, choose Plentymarkets field from which the Supplier Part Number you provided to Wayfair comes from. You can choose from these three fields:
-           **a.** *Variation No.*
-           **b.**  *EAN*
-           **c.** *Marketplace-specific SKU*: choose this option only if none of the two Plentymarkets fields above match with the Supplier Part Number you provided to Wayfair. If you choose this option, please follow the instructions below (Matching an incoming order using the marketplace-specific SKU).
-
-4. Click **Save**.
-
-#### Matching an incoming order using the marketplace-specific SKU.
-
-1. Go to **Item >> Edit Item** and click on the **Item ID** of the item that you wish to match with incoming Wayfair orders.
-
-2. You will be redirected to the **Settings** tab of the chosen item. Click on the tab **Availability**.
-
-3. In this tab, there are four different sections. The one that we want is the **SKU** section.
-
-4. Click on the **Add** button (the with cross in grey background)
-
-5. A new window will be opened. In the first field(**Referrer**), choose the **Wayfair** order referrer from the dropdown menu.
-
-6. In the third field (**SKU**), enter the **Supplier Part Number**.
-7. Click on **Add**.
-
-8. Click on **Save**.
-
-9. Repeat the same process for all items that you are selling on Wayfair.
-
-## Setting up the order fulfillment.
-
-A working order fulfillment with the Wayfair plugin requires to set up **Shipping Profile Mappings** and **Event Procedures**. Carry out the following instructions:
-
-### Create a new shipping service provider
-
-1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping service provider**
-
-2. Click on **+ New** in order to create a new **shipping service provider**.
-
-3. Enter **Wayfair Shipping** in the fields **Name (de)** and **Name (backend)**.
-
-4. Click in the field **Shipping service provider** and choose **WayfairShipping**.
-
-5. Click on **Save**.
-
-### Create a new shipping profile
 
 1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping Profiles**
 
@@ -117,8 +61,7 @@ A working order fulfillment with the Wayfair plugin requires to set up **Shippin
 
 9. Scroll to the top of the page, and click on the **save** button. All the other rows and their respective data entries can be left empty.
 
-### Creating a new event procedure
-
+## 4. Automatically selecting the Wayfair Shipping Profile for Wayfair orders
 
 1. Go to **System >> Orders >> Events**
 
@@ -144,23 +87,43 @@ A working order fulfillment with the Wayfair plugin requires to set up **Shippin
 
 12. Click on the **save** button.
 
-## 7. Configuring the warehouse mapping.
+### 5. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
+In order to properly handle incoming orders from Wayfair, the Wayfair plugin must match the Supplier Part Numbers in Wayfair's systems with a specific field of Item Variations in Plentymarkets. By default, the Wayfair plugin operates on the assumption that the `Variation Number` **(not to be confused with the Variation's ID)** of an Item's Variation in Plentymarkets will match the Wayfair Supplier Part Number.
 
-In order to update the inventory data in Wayfair's system, you need to map the warehouse ID's in your Plentymarkets system to the warehouse ID in Wayfair's system.
+If the Wayfair Supplier Part Numbers for your organization are to be reflected in an alternative field in your Plentymarkets Item Variations, change the value of [the `Item Mapping Method` setting](settings_guide.md#item-mapping-method) and update the Variations accordingly.
 
-1. Go to **System >> Markets >> Wayfair >> Home >> Tab: Warehouses**
+## 5. Making items available for sale on Wayfair
+Items that you want to sell on the Wayfair market must be considered active in Plentymarkets. The Plentymarkets user may also choose limit which Items are for sale on Wayfair. **Note that Inventory and ordered items are controlled at the `Variation` level.**
 
-2. Click on **Add mapping**
+To ensure that an Item is available for sale, follow these instructions:
 
-3. In the field **Warehouse** select the warehouse you want to map.
+1. From the main Plentymarkets page, go to `Item` >> `Edit item`
 
-4. In the field **Supplier ID**, enter your corresponding Wayfair Supplier ID.
+2. Search for item(s) and open them
 
-5. Click on **Save**
+3. **For each item**, click `Variations` and open them
 
-## 8. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
+4. **For each Variation**:
 
-### 8.1 Create Event for Plentymarkets Orders that sends shipment information to Wayfair
+    1. On the `Settings` tab, make sure that the `Active` checkbox in the `Availability Section`is checked.
+
+    2. If [the `Send all inventory items to Wayfair?` setting](settings_guide.md#send-all-inventory-items-to-wayfair) is **disabled**, go to the `Availability` tab of the Variation and add "Wayfair" to the list in the `Markets` area.
+
+    3. Click the `Save` button next to the Variation `ID` (not the higher-up button for the Item).
+
+
+## 6. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
+
+In order to update the inventory data in Wayfair's system, you need to map the Warehouses in your Plentymarkets system to the Supplier IDs in Wayfair's system, on the [Warehouses](settings_guide.md#warehouses-page) page of the plugin's settings.
+
+## 7. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
+
+### 7.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
+Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update the [Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
+
+If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.
+
+### 7.2 Creating an Event for Plentymarkets Orders that sends shipment information to Wayfair
 
 1. Click **Setup** in the top navigation bar then go to **Orders >> Events**
 ![Create Event](https://i.ibb.co/NjDtY05/asn-02.png "Create Event")
@@ -188,8 +151,3 @@ In order to update the inventory data in Wayfair's system, you need to map the w
 
 The final settings result should look similar to this:
 ![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
-
-### 8.2 Set the Wayfair Plugin to use the correct information
-Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update [the Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
-
-If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -9,8 +9,13 @@
 
 
 ## 1. Authorizing the Wayfair Plugin to access Wayfair interfaces
-After the plugin is installed in your Plentymarkets system, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces:
+After the plugin is installed in your Plentymarkets Plugin Set, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces.
 
+* **The authorization procedure must be performed for any Plugin Set that contains the Wayfair plugin**.
+* Copying a Plugin Set will copy the authorization information to the new plugin set.
+* An exported or imported Plugin set may include the authorization information.
+
+The authorization steps are as follows:
 1. From the main Plentymarkets page, go to `Plugins` >> `Plugin set overview`
 
 2. Locate the Plugin Set that is linked to the client with which Wayfair will be used.
@@ -36,57 +41,8 @@ An order referrer in Plentymarkets denotes the sales channel on which an order w
 
 3. Click on **Save**.
 
-## 3. Creating a new shipping profile for shipping through Wayfair
-**TODO: when and why**
-
-**TODO: what comes with the plugin**
-
-**TODO: what needs to be manually created - ???different for "Wayfair shipping" VS "Own account" shipping???**
-
-
-1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping Profiles**
-
-2. Click on **+ New** to create a new shipping profile.
-
-3. You will see a table in which you have to enter data.
-
-4. In the first row, click on the dropdown menu, and choose the *Shipping service provider** you have just created (should be **WayfairShipping** if you followed our instructions)
-
-5. In the second and third row, enter a name (we recommend **WayfairShipping** for simplicity). You should also choose a language in the second row, third column.
-
-6. In the fourth row, choose the flag number 6 or 126 (which represent the Wayfair colors).
-
-7. In the fifth column, choose **priority n1** (the two stars).
-
-8. In the seventeenth column (**Order referrer**), place a check mark next to **Wayfair** (if there are more than one, choose all).
-
-9. Scroll to the top of the page, and click on the **save** button. All the other rows and their respective data entries can be left empty.
-
-## 4. Automatically selecting the Wayfair Shipping Profile for Wayfair orders
-
-1. Go to **System >> Orders >> Events**
-
-2. Click on **Add event procedure** (the "+" button on the left of the page).
-
-3. Enter the name **Wayfair order Shipping Mapping**.
-
-4. Select the event **New order** from the dropdown menu.
-
-5. Click on the **save** button.
-
-6. You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a check mark next to **Active**.
-
-7. Click on **Add filter**, and go to **Order >> Referrer** to add the referrer as a filter.
-
-8. In the **Filter** section, a box should appear with a list of all available **Order referrers**. Place a check mark next to all **Wayfair** order referrers.
-
-9. Click on **Add procedure**, and go to **Order >> Change shipping profile**. Click on **+ add**.
-
-10. In the **Procedures** section, click on the **expand** button next to **change shipping profile** (left-most arrow).
-
-11. Choose the **shipping profile** you created before (should be **WayfairShipping** if you followed our instructions).
-
-12. Click on the **save** button.
+## 3. Setting up Plentymarkets for shipping through Wayfair
+To ensure proper integrations with Wayfair when shipping order items, follow the procedures outlined in  [the Wayfair Shipping instructions](wayfair_shipping.md).
 
 ## 5. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
 In order to properly handle incoming orders from Wayfair, the Wayfair plugin must match the Supplier Part Numbers in Wayfair's systems with a specific field of Item Variations in Plentymarkets. By default, the Wayfair plugin operates on the assumption that the `Variation Number` **(not to be confused with the Variation's ID)** of an Item's Variation in Plentymarkets will match the Wayfair Supplier Part Number.

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -113,7 +113,9 @@ The final settings result should look similar to this:
 
 ![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
 
-## 9. Performing the first Inventory Synchronization
+## 9. Performing the first inventory synchronization
 Once everything has been set up, the it is time to start listing items for sale on Wayfair.
 
-Finalize the setup by initiating a full inventory synchronization on the [Full Inventory](settings_guide.md#full-inventory-page) page of the [Wayfair Market Settings](settings_guide.md)
+Finalize the setup by initiating a full inventory synchronization on the [Full Inventory](settings_guide.md#full-inventory-page) page of the [Wayfair Market Settings](settings_guide.md).
+
+**After this first inventory synchronization, the Wayfair plugin will periodically send inventory updates to Wayfair, without any further manual activations.**

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -87,12 +87,12 @@ An order referrer in Plentymarkets denotes the sales channel on which an order w
 
 12. Click on the **save** button.
 
-### 5. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
+## 5. Matching items ordered on Wayfair with Item Variations in Plentymarkets:
 In order to properly handle incoming orders from Wayfair, the Wayfair plugin must match the Supplier Part Numbers in Wayfair's systems with a specific field of Item Variations in Plentymarkets. By default, the Wayfair plugin operates on the assumption that the `Variation Number` **(not to be confused with the Variation's ID)** of an Item's Variation in Plentymarkets will match the Wayfair Supplier Part Number.
 
 If the Wayfair Supplier Part Numbers for your organization are to be reflected in an alternative field in your Plentymarkets Item Variations, change the value of [the `Item Mapping Method` setting](settings_guide.md#item-mapping-method) and update the Variations accordingly.
 
-## 5. Making items available for sale on Wayfair
+## 6. Making items available for sale on Wayfair
 Items that you want to sell on the Wayfair market must be considered active in Plentymarkets. The Plentymarkets user may also choose limit which Items are for sale on Wayfair. **Note that Inventory and ordered items are controlled at the `Variation` level.**
 
 To ensure that an Item is available for sale, follow these instructions:
@@ -112,18 +112,18 @@ To ensure that an Item is available for sale, follow these instructions:
     3. Click the `Save` button next to the Variation `ID` (not the higher-up button for the Item).
 
 
-## 6. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
+## 7. Configuring the Warehouse mappings to match Wayfair Supplier IDs.
 
 In order to update the inventory data in Wayfair's system, you need to map the Warehouses in your Plentymarkets system to the Supplier IDs in Wayfair's system, on the [Warehouses](settings_guide.md#warehouses-page) page of the plugin's settings.
 
-## 7. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
+## 8. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
 
-### 7.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
+### 8.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
 Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update the [Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
 
 If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.
 
-### 7.2 Creating an Event for Plentymarkets Orders that sends shipment information to Wayfair
+### 8.2 Creating an Event for Plentymarkets Orders that sends shipment information to Wayfair
 
 1. Click **Setup** in the top navigation bar then go to **Orders >> Events**
 ![Create Event](https://i.ibb.co/NjDtY05/asn-02.png "Create Event")

--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -1,0 +1,195 @@
+## Authorizing the Wayfair Plugin to access Wayfair interfaces
+After the plugin is installed in your Plentymarkets system, the plugin must be configured to use the correct credentials when connecting to Wayfair's interfaces.
+
+1. Go to **Plugins >> Plugin Overview**
+
+2. Select the plugin set that contains the Wayfair plugin
+
+3. Click on the "Wayfair " name in the plugin set details
+
+4. Go to **Configuration >> Global Settings**
+
+5. Enter the Client ID and Client Secret you received when creating the application in Extranet into the fields **Client ID** and **Client Secret**.
+
+6. Change **Mode** to **Live**.
+7. **Save** the settings.
+
+## 4. Activating the order referrer
+
+An order referrer indicates the sales channel on which an order was generated. You have to activate the Wayfair order referrer in order to link items, properties etc. with Wayfair.
+
+### Activating the order referrer for Wayfair:
+
+1. Go to **System >> Orders >> Order referrer**.
+
+2. Place a check mark next to the **Wayfair** order referrer.
+
+3. Click on **Save**.
+
+## 5. Making an item available for Wayfair.
+
+Items that you want to sell on the Wayfair website have to be active and available for Wayfair. These settings are carried out in the **Item >> Edit item >> Open item>> Tab: Variation ID**. Please keep in mind that you have to carry out these settings for all the items that you wish to sell on Wayfair.
+
+### Setting the item availability for Wayfair:
+
+1. Go to **Item >> Edit Item** then click on the **Item ID** of the item that you wish to make available for Wayfair.
+
+2. You will be redirected to the **Settings** tab of the chosen item. In this tab, there is a section called **Availability**. Place a check mark next to the option **Active** in this section.
+
+3. Click on the tab **Availability**.
+
+4. Click in the selection field in the **Markets** section. A list with all available markets is displayed.
+
+5. Place a check mark next to the option **Wayfair**.
+
+6. Click on **Add**. The market is now added.
+
+7. Click on **Save**. The item is now available for Wayfair.
+
+### 6. Matching an incoming order with your items in Plentymarkets:
+In order to match an item in Wayfair's database, which is defined by the Supplier Part Number you have provided to Wayfair, with your items in Plentymarkets, you need to configure which Plentymarkets field the Wayfair Supplier Part Number should match with.
+
+To do so, follow the instructions below:
+
+1. Go to **Setup >> System >> Markets >> Wayfair >> Home**.
+
+2. Once the homepage of the plugin has loaded, click on **Settings**.
+
+3. Under **Item Mapping Method**, choose Plentymarkets field from which the Supplier Part Number you provided to Wayfair comes from. You can choose from these three fields:
+           **a.** *Variation No.*
+           **b.**  *EAN*
+           **c.** *Marketplace-specific SKU*: choose this option only if none of the two Plentymarkets fields above match with the Supplier Part Number you provided to Wayfair. If you choose this option, please follow the instructions below (Matching an incoming order using the marketplace-specific SKU).
+
+4. Click **Save**.
+
+#### Matching an incoming order using the marketplace-specific SKU.
+
+1. Go to **Item >> Edit Item** and click on the **Item ID** of the item that you wish to match with incoming Wayfair orders.
+
+2. You will be redirected to the **Settings** tab of the chosen item. Click on the tab **Availability**.
+
+3. In this tab, there are four different sections. The one that we want is the **SKU** section.
+
+4. Click on the **Add** button (the with cross in grey background)
+
+5. A new window will be opened. In the first field(**Referrer**), choose the **Wayfair** order referrer from the dropdown menu.
+
+6. In the third field (**SKU**), enter the **Supplier Part Number**.
+7. Click on **Add**.
+
+8. Click on **Save**.
+
+9. Repeat the same process for all items that you are selling on Wayfair.
+
+## Setting up the order fulfillment.
+
+A working order fulfillment with the Wayfair plugin requires to set up **Shipping Profile Mappings** and **Event Procedures**. Carry out the following instructions:
+
+### Create a new shipping service provider
+
+1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping service provider**
+
+2. Click on **+ New** in order to create a new **shipping service provider**.
+
+3. Enter **Wayfair Shipping** in the fields **Name (de)** and **Name (backend)**.
+
+4. Click in the field **Shipping service provider** and choose **WayfairShipping**.
+
+5. Click on **Save**.
+
+### Create a new shipping profile
+
+1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping Profiles**
+
+2. Click on **+ New** to create a new shipping profile.
+
+3. You will see a table in which you have to enter data.
+
+4. In the first row, click on the dropdown menu, and choose the *Shipping service provider** you have just created (should be **WayfairShipping** if you followed our instructions)
+
+5. In the second and third row, enter a name (we recommend **WayfairShipping** for simplicity). You should also choose a language in the second row, third column.
+
+6. In the fourth row, choose the flag number 6 or 126 (which represent the Wayfair colors).
+
+7. In the fifth column, choose **priority n1** (the two stars).
+
+8. In the seventeenth column (**Order referrer**), place a check mark next to **Wayfair** (if there are more than one, choose all).
+
+9. Scroll to the top of the page, and click on the **save** button. All the other rows and their respective data entries can be left empty.
+
+### Creating a new event procedure
+
+
+1. Go to **System >> Orders >> Events**
+
+2. Click on **Add event procedure** (the "+" button on the left of the page).
+
+3. Enter the name **Wayfair order Shipping Mapping**.
+
+4. Select the event **New order** from the dropdown menu.
+
+5. Click on the **save** button.
+
+6. You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a check mark next to **Active**.
+
+7. Click on **Add filter**, and go to **Order >> Referrer** to add the referrer as a filter.
+
+8. In the **Filter** section, a box should appear with a list of all available **Order referrers**. Place a check mark next to all **Wayfair** order referrers.
+
+9. Click on **Add procedure**, and go to **Order >> Change shipping profile**. Click on **+ add**.
+
+10. In the **Procedures** section, click on the **expand** button next to **change shipping profile** (left-most arrow).
+
+11. Choose the **shipping profile** you created before (should be **WayfairShipping** if you followed our instructions).
+
+12. Click on the **save** button.
+
+## 7. Configuring the warehouse mapping.
+
+In order to update the inventory data in Wayfair's system, you need to map the warehouse ID's in your Plentymarkets system to the warehouse ID in Wayfair's system.
+
+1. Go to **System >> Markets >> Wayfair >> Home >> Tab: Warehouses**
+
+2. Click on **Add mapping**
+
+3. In the field **Warehouse** select the warehouse you want to map.
+
+4. In the field **Supplier ID**, enter your corresponding Wayfair Supplier ID.
+
+5. Click on **Save**
+
+## 8. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
+
+### 8.1 Create Event for Plentymarkets Orders that sends shipment information to Wayfair
+
+1. Click **Setup** in the top navigation bar then go to **Orders >> Events**
+![Create Event](https://i.ibb.co/NjDtY05/asn-02.png "Create Event")
+
+2.	Click on **Add event procedure** (the "+" button on the left of the page)
+
+3.	Enter any **Name**
+
+4.	Select **Status change** (in the category **Order Change**) in the **Event** field.
+
+5.	In the field below **Event** select the status change that should initiate the sending of an ASN to Wayfair, such as **in preparation for shipping**.
+
+6.	Click the **Save** button.
+
+7.	You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a checkmark next to **Active**.
+
+8.  Click on **Add Filter**, and go to **Order >> Referrer** to add the referrer as a filter (see screenshot below)
+![Event Referrer](https://i.ibb.co/TwKLvJ5/asn-03.png "Event Referrer")
+
+9.	In the **Filter** section, a box should appear with a list of all available Order referrers. Place a checkmark next to all **Wayfair** order referrers.
+![Wayfair Referrer](https://i.ibb.co/yYpLp8q/asn-04.png "Wayfair Referrer")
+
+10. Click on **Add procedure**, and go to **Plugins >> Send Ship Confirmation (ASN) to Wayfair**. Click on **+ add**.
+![Add Procedure](https://i.ibb.co/xfGrhFP/asn-05.png "Add Procedure")
+
+The final settings result should look similar to this:
+![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
+
+### 8.2 Set the Wayfair Plugin to use the correct information
+Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update [the Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
+
+If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -1,11 +1,44 @@
-In order to connect Wayfair to Plentymarkets, you need to enter API credentials. To receive them, you must first send an email to ERPSupport@wayfair.com and provide the following information:
+# Wayfair plugin: Getting API Credentials
+
+In order for the Wayfair plugin to connect to Wayfair's systems, you need to provide your unique API credentials.
+
+To receive the API credentials for you organization, follow these steps:
+
+## 1. Send an Email to Wayfair
+
+Send an email to ERPSupport@wayfair.com to request assistance:
 
 - Subject : Access to Plentymarkets plugin / "Name of your company" (SuID)
-- Information contact
-- Which functionalities you plan to use.
+- Body:
+    - Contact information
+    - Descriptions of your organizations' plans and needs
+    - Any important dates regarding Plentymarkets >> Wayfair integrations.
 
-You will shortly receive an email back, containing a confirmation that you have been granted access to the API tools, as well as your **Supplier ID(s)**. Next, you need to head over to your Extranet account at partners.wayfair.com. In the banner, you should see a tab named "Developer". If you don’t see it in the banner, then hover over the "More" tab, and it should appear in the dropdown menu.
+You will promptly receive a response containing these details:
+- Confirmation of access to
+- Supplier ID(s)
 
-Hover over the "Developer" tab, and click on "Application". You should be redirected to a new page. On this new page, click on the button named " + New Application", and give a name and description to your application
+## 2. Generate Application Credentials
 
-Click on "Save", then you should be shown a ClientID and Client Secret, which are the credentials you will need to use for the Wayfair plugin. Save these somewhere secure, especially the Client Secret, as you will only be able to see it once.
+1. Log in to your Partner Home account at partners.wayfair.com
+
+2. Find the `Developer` menu. It may be on the top banner of the page. Otherwise, it is accessible in the `More` menu in the banner.
+
+3. Activate the `Developer` menu, and click on `Application`. You should be redirected to a new page.
+
+4. On the `Application Management` page, click the `+ New Application` button at the bottom.
+
+5. Provide a `Name` and `Description` for the new Application
+
+6. Use the slider switch at the bottom of dialog to set it to `Production`, unless otherwise instructed by Wayfair.
+
+7. Click `Save` on the dialog, which will display the application's credentials - `Client ID` and `Client Secret`.
+
+8. Copy the `Client ID` and `Client Secret` to a secure location.
+    * **The `Client Secret` cannot be retrieved after this point and a new one must be generated if the original is lost.**
+
+    * These credentials will be used for [authorizing the Wayfair plugin](initial_setup.md#1-authorizing-the-wayfair-plugin-to-access-wayfair-interfaces) for use of Wayfair's systems.
+
+9. Close the credentials dialog to protect the information.
+
+10. Review the [supplementary information on credentials](tips_and_tricks.md#protecting-your-credentials).

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -15,8 +15,8 @@ Send an email to ERPSupport@wayfair.com to request assistance:
     - Date when you are ready to use the Wayfair Plentymarkets Plugin.
 
 You will promptly receive a response containing these details:
-- Confirmation of access to
-- Supplier ID(s)
+- Confirmation of your API access being set up
+- Supplier ID(s) for your Warehouses
 
 ## 2. Generate Application Credentials
 

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -29,8 +29,8 @@ You will promptly receive a response containing these details:
 4. On the `Application Management` page, click the `+ New Application` button at the bottom.
 
 5. On the `New Application` form, provide the new application's details:
-    *  `Name`: A useful identifier such as "[My Supplier] Plentymarkets Plugin."
-    * `Description`: any information to make your organization and Wayfair of the application's purpose.
+    *  `Name`: A useful identifier such as "[My Supplier] Plentymarkets plugin."
+    * `Description`: something like "Plentymarkets plugin application for [My Supplier] Go-Live in Fall 2020".
 
 6. Use the slider switch at the bottom of dialog to set it to `Production`, unless otherwise instructed by Wayfair.
 

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -8,11 +8,11 @@ To receive the API credentials for you organization, follow these steps:
 
 Send an email to ERPSupport@wayfair.com to request assistance:
 
-- Subject : Access to Plentymarkets plugin / "Name of your company" (SuID)
+- Subject : Access to Plentymarkets plugin / (Name of your company) (Wayfair Supplier ID)
 - Body:
-    - Contact information
-    - Descriptions of your organizations' plans and needs
-    - Any important dates regarding Plentymarkets >> Wayfair integrations.
+    - Your contact information.
+    - Short description of how you intend to use the Plentymarkets plugin.
+    - Date when you are ready to use the Wayfair Plentymarkets Plugin.
 
 You will promptly receive a response containing these details:
 - Confirmation of access to
@@ -28,7 +28,9 @@ You will promptly receive a response containing these details:
 
 4. On the `Application Management` page, click the `+ New Application` button at the bottom.
 
-5. Provide a `Name` and `Description` for the new Application
+5. On the `New Application` form, provide the new application's details:
+    *  `Name`: A useful identifier such as "[My Supplier] Plentymarkets Plugin."
+    * `Description`: any information to make your organization and Wayfair of the application's purpose.
 
 6. Use the slider switch at the bottom of dialog to set it to `Production`, unless otherwise instructed by Wayfair.
 

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -15,16 +15,14 @@ Send an email to ERPSupport@wayfair.com to request assistance:
     - Date when you are ready to use the Wayfair Plentymarkets Plugin.
 
 You will promptly receive a response containing these details:
-- Confirmation of your API access being set up
-- Supplier ID(s) for your Warehouses
+- Confirmation of your API access being set up.
+- Supplier ID(s) for your Warehouses.
 
 ## 2. Generate Application Credentials
 
-1. Log in to your Partner Home account at partners.wayfair.com
+1. Go to https://partners.wayfair.com/developer/applications
 
-2. Find the `Developer` menu. It may be on the top banner of the page. Otherwise, it is accessible in the `More` menu in the banner.
-
-3. Activate the `Developer` menu, and click on `Application`. You should be redirected to a new page.
+2. Enter your Wayfair Partner Home credentials. You should be redirected to the `Application Management` page for Wayfair.
 
 4. On the `Application Management` page, click the `+ New Application` button at the bottom.
 

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -1,0 +1,11 @@
+In order to connect Wayfair to Plentymarkets, you need to enter API credentials. To receive them, you must first send an email to ERPSupport@wayfair.com and provide the following information:
+
+- Subject : Access to Plentymarkets plugin / "Name of your company" (SuID)
+- Information contact
+- Which functionalities you plan to use.
+
+You will shortly receive an email back, containing a confirmation that you have been granted access to the API tools, as well as your **Supplier ID(s)**. Next, you need to head over to your Extranet account at partners.wayfair.com. In the banner, you should see a tab named "Developer". If you don’t see it in the banner, then hover over the "More" tab, and it should appear in the dropdown menu.
+
+Hover over the "Developer" tab, and click on "Application". You should be redirected to a new page. On this new page, click on the button named " + New Application", and give a name and description to your application
+
+Click on "Save", then you should be shown a ClientID and Client Secret, which are the credentials you will need to use for the Wayfair plugin. Save these somewhere secure, especially the Client Secret, as you will only be able to see it once.

--- a/meta/documents/user_guide/en/obtaining_credentials.md
+++ b/meta/documents/user_guide/en/obtaining_credentials.md
@@ -6,7 +6,7 @@ To receive the API credentials for you organization, follow these steps:
 
 ## 1. Send an Email to Wayfair
 
-Send an email to ERPSupport@wayfair.com to request assistance:
+Please send an email to your Wayfair Account Manager, and copy (CC) ERPSupport@wayfair.com to request assistance:
 
 - Subject : Access to Plentymarkets plugin / (Name of your company) (Wayfair Supplier ID)
 - Body:

--- a/meta/documents/user_guide/en/plugin_installation.md
+++ b/meta/documents/user_guide/en/plugin_installation.md
@@ -1,3 +1,5 @@
+# Wayfair plugin: Installation instructions
+
 1. Login to the Plentymarkets system
 
 2. Go to **plugins >> plentyMarketplace**, which will use the system owner’s credentials to log you in on the Marketplace

--- a/meta/documents/user_guide/en/plugin_installation.md
+++ b/meta/documents/user_guide/en/plugin_installation.md
@@ -1,45 +1,71 @@
 # Wayfair plugin: Installation instructions
+The Wayfair plugin is available for **free** on the official plentyMarketplace from Plentymarkets. This document covers the steps required for making it available for use in a Plentymarkets system.
 
-1. Login to the Plentymarkets system
+## 1. Making the Wayfair plugin available in Plentymarkets
+Plentymarkets systems do not come with the Wayfair plugin by default.
+Follow these steps to make it available for use:
 
-2. Go to **plugins >> plentyMarketplace**, which will use the system owner’s credentials to log you in on the Marketplace
+1. Log in to the Plentymarkets system.
 
-3. Click the search button  in the top-right corner of the page
+2. From the main Plentymarkets page, go to `plugins` >> `plentyMarketplace`, which will use the Plentymarkets system's owner’s credentials to log you in on the plentyMarketplace website.
 
-4. Enter “Wayfair” into the box and press enter
+3. Click the search button  in the top-right corner of the page.
 
-5. If “Already purchased” appears on the page, skip to step 8
+4. Enter "Wayfair" into the box and press enter.
 
-6. Click the **go to checkout** button
-7. Complete the purchasing form
-    1. Accept terms and conditions
-    2. Click **order now**
+5. If a `You have purchased this plugin` banner appears on the top page and/or an `Already purchased` appears on the page, skip to the instructions on [installing the plugin in a Plugin Set](#2-installing-the-wayfair-plugin-in-a-plugin-set).
 
-8. Return to the Plentymarkets system, and go to **Plugins >> Plugin Overview**.
+6. Click the `Go to checkout` button.
 
-9. Find/Create a Plugin Set where the plugin is to be installed - the proper plugin set will be marked as **Linked to** your "shop."
+7. Complete all fields on the purchasing form.
 
-10. Un-check the **installed** checkbox
+8. Accept terms and conditions.
 
-11. Check the **plentyMarketplace** checkbox
+9. Click `Order now` and await confirmation. The plugin will be soon be available in the system.
 
-12. Type “Wayfair” into the **name** field
+## 2. Installing the Wayfair plugin in a Plugin Set
+To use the functions of the Wayfair plugin, it must be installed in the Plentymarkets system's active plugin set(s). Follow these instructions to complete the installation:
 
-13. Click **search** to find the appropriate plugin - only one should appear, with the marketplace icon in the Source column.
+1. From the main Plentymarkets page, go to `Plugins` >> `Plugin set overview`
+    * **Do not select the deprecated, similarly named `Plugin overview` option, if it appears in the menu.**
 
-14. Click the **install** button in the Wayfair row
+    * The screen should show a list of plugin sets, with a set of buttons for each one.
 
-15. Complete the pop-up modal
-    1. In the drop-down, choose [the newest plugin version](https://github.com/wayfair-contribs/plentymarkets-plugin/releases).
+2. Create the Plugin Set where the plugin is to be installed, if it the desired Plugin Set does not yet exist.
 
-    2. Click **install**
+    * If you already have other plugins installed, you may wish to use a copy of an existing Plugin Set via its dedicated `Copy plugin set`.
 
-16. Refresh the Plugin Overview page
+    * Your Plentymarkets license may limit the number of Plugin Sets that can exist at one time.
 
-17. Click on the name of the plugin set where the plugin was installed
+3. Configure the Plugin Set(s) to be used by Plentymarkets
+    * The `Linked clients` field for the Plugin Set should contain the names of all Plentymarkets Shop(s) for which Wayfair plugin functionality is desired.
 
-18. Click the **Activate** button in the Wayfair plugin row of the plugin set
+    * Optionally use the `Link clients and plugin sets` to modify the linkages between clients and Plugin Sets.
 
-19. Click the save icon  above the list, and wait for the progress bar to complete. A timestamp will display at successful completion.
+4. Click the `Edit plugin set` button for the Plugin Set in which the Wayfair plugin is to be installed.
 
-20. If an error symbol appears, check the Plentymarkets logs for plugin build and deployment failures
+5. Click the `+ Add plugin` button
+
+6. `Wayfair` should appear in the list of plugins
+
+    * If there are many plugins, type "Wayfair" into the `Search` box
+
+7. Click on the `Wayfair` entry in the list. The Wayfair logo should appear, below an `Install` button.
+
+    * If you have previously installed the Wayfair plugin via the "git" channel, there may multiple entries for "Wayfair." Please select the entry that has the "Marketplace" source.
+
+8. Review the information on the page.
+
+9. In the `Select version` drop-down menu, choose [the newest plugin version](https://github.com/wayfair-contribs/plentymarkets-plugin/releases) if it is not already selected.
+
+10. Click the `Install` button at the top of the page. You will be redirected to the individual Plugin Set's details.
+
+11. Verify that a row exists on the page with the `Name` displayed as "Wayfair" and the `Installed` version showing as the desired version
+
+12. In the `Active` column for the "Wayfair" row, click on the switch so that it moves to the right-side, enabled position. **Failure to activate the Wayfair plugin will prevent its functionalities from being available**.
+
+13. Click the `Deploy plugin set` button (appears as a Save button) at the top of the page. A progress bar will appear while the plugin is installed.
+
+14. Confirm that the `Deployed` column for the "Wayfair" row is now populated, and it reflects the value in the `Installed` column.
+
+15. Log out of the Plentymarkets system, then log back in, to ensure that the changes are now in effect.

--- a/meta/documents/user_guide/en/plugin_installation.md
+++ b/meta/documents/user_guide/en/plugin_installation.md
@@ -9,7 +9,7 @@ Follow these steps to make it available for use:
 
 2. From the main Plentymarkets page, go to `plugins` >> `plentyMarketplace`, which will use the Plentymarkets system's owner’s credentials to log you in on the plentyMarketplace website.
 
-3. Click the search button  in the top-right corner of the page.
+3. Click the search button in the top-right corner of the page.
 
 4. Enter "Wayfair" into the box and press enter.
 

--- a/meta/documents/user_guide/en/plugin_installation.md
+++ b/meta/documents/user_guide/en/plugin_installation.md
@@ -1,0 +1,43 @@
+1. Login to the Plentymarkets system
+
+2. Go to **plugins >> plentyMarketplace**, which will use the system owner’s credentials to log you in on the Marketplace
+
+3. Click the search button  in the top-right corner of the page
+
+4. Enter “Wayfair” into the box and press enter
+
+5. If “Already purchased” appears on the page, skip to step 8
+
+6. Click the **go to checkout** button
+7. Complete the purchasing form
+    1. Accept terms and conditions
+    2. Click **order now**
+
+8. Return to the Plentymarkets system, and go to **Plugins >> Plugin Overview**.
+
+9. Find/Create a Plugin Set where the plugin is to be installed - the proper plugin set will be marked as **Linked to** your "shop."
+
+10. Un-check the **installed** checkbox
+
+11. Check the **plentyMarketplace** checkbox
+
+12. Type “Wayfair” into the **name** field
+
+13. Click **search** to find the appropriate plugin - only one should appear, with the marketplace icon in the Source column.
+
+14. Click the **install** button in the Wayfair row
+
+15. Complete the pop-up modal
+    1. (Optional) in the drop-down, choose a different version to install - you probably should be using the newest one.
+
+    2. Click **install**
+
+16. Refresh the Plugin Overview page
+
+17. Click on the name of the plugin set where the plugin was installed
+
+18. Click the **Activate** button in the Wayfair plugin row of the plugin set
+
+19. Click the save icon  above the list, and wait for the progress bar to complete. A timestamp will display at successful completion.
+
+20. If an error symbol appears, check the Plentymarkets logs for plugin build and deployment failures

--- a/meta/documents/user_guide/en/plugin_installation.md
+++ b/meta/documents/user_guide/en/plugin_installation.md
@@ -30,7 +30,7 @@
 14. Click the **install** button in the Wayfair row
 
 15. Complete the pop-up modal
-    1. (Optional) in the drop-down, choose a different version to install - you probably should be using the newest one.
+    1. In the drop-down, choose [the newest plugin version](https://github.com/wayfair-contribs/plentymarkets-plugin/releases).
 
     2. Click **install**
 

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -67,7 +67,7 @@ When the `Item Mapping Method` is set to `EAN`, each Item Variation in Plentymar
 
 3. **For each Item**, click on the item in the search results, then click `Variations`
 
-3. **For each Variation**:
+4. **For each Variation**:
     1. Click on the `Settings` tab
     2. In the `Barcode` section, pick a barcode type, then click the `Add` button, then enter the barcode value in the `Code` field. The Barcode should match the Wayfair Supplier Part Number.
     3. Click the `Save` button at the Variation level (not to be confused with the `Save` button for the Item, a few rows above)

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -1,6 +1,6 @@
 # Wayfair Plugin: Wayfair Market Settings
 The Wayfair plugin comes with a collection of settings for controlling the plugin's behavior.
-These settings should only be configured after the authorization settings for the plugin have been configured in the active Plugin Set.
+These settings should only be configured after the [authorization settings for the plugin](initial_setup.md#1-authorizing-the-wayfair-plugin-to-access-wayfair-interfaces) have been configured for the active Plugin Set.
 
 # Opening the settings page
 To locate the settings:

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -50,7 +50,37 @@ The `Default Shipping Provider` setting is a legacy setting that no longer impac
 **If this setting appears in your system, Wayfair strongly recommends that you upgrade your plugin to a newer version.**
 
 ### Item Mapping Method
-The `Item Mapping Method` setting determines the behavior for matching the Plentymarkets Item Variations to the Wayfair Products. It is used when the inventory listings are sent to Wayfair, and also to select the requested products in a Wayfair Purchase Order.
+The `Item Mapping Method` setting determines the behavior for matching the Plentymarkets Item Variations to the Wayfair Products. It is used when the inventory listings are sent to Wayfair, and also to select the requested products in a Wayfair Purchase Order. The Plentymarkets user should configure this setting to match the way their Item Variations are populated.
+
+By default, the `Variation Number` field is used for mapping Wayfair Orders' items to Plentymarkets Item Variations.
+The other options are `EAN` (Barcode) and `SKU`.
+
+#### Using EAN (Barcode) as the Item Mapping Method
+When the `Item Mapping Method` is set to `EAN`, each Item Variation in Plentymarkets should be set up to have a Barcode that mirrors the Wayfair Supplier Part Number that Wayfair will send in incoming order data:
+1. From the main Plentymarkets page, go to `Item` >> `Edit Item`
+
+2. Search for items to be sold on Wayfair
+
+3. **For each Item**, click on the item in the search results, then click `Variations`
+
+3. **For each Variation**:
+    1. Click on the `Settings` tab
+    2. In the `Barcode` section, pick a barcode type, then click the `Add` button, then enter the barcode value in the `Code` field. The Barcode should match the Wayfair Supplier Part Number.
+    3. Click the `Save` button at the Variation level (not to be confused with the `Save` button for the Item, a few rows above)
+
+#### Using SKU as the Item Mapping Method
+When the `Item Mapping Method` is set to `SKU`, each Item Variation in Plentymarkets should be set up to have a Wayfair-specific SKU that mirrors the Wayfair Supplier Part Number that Wayfair will send in incoming order data:
+1. From the main Plentymarkets page, go to `Item` >> `Edit Item`
+
+2. Search for items to be sold on Wayfair
+
+3. **For each Item**, click on the item in the search results, then click `Variations`
+
+3. **For each Variation**:
+    1. Click on the `Availability` tab
+    2. In the `SKU` section, click the `Add` button
+    3. In the pop-up window, choose `Wayfair` for the `Referrer` then enter the Wayfair Supplier Part Number in the `SKU` field, then click `Add`
+    4. Click the `Save` button at the Variation level (not to be confused with the `Save` button for the Item, a few rows above)
 
 ### Import orders since
 The optional `Import orders since` setting determines a date on which new Wayfair purchase orders are considered eligible for being imported into the Plentymarkets system. This setting can improve performance by preventing the Wayfair plugin from requesting orders created before the specified date. It can also be used to prevent the Plentymarkets system from accepting Orders prior to the desired "go-live date."
@@ -86,7 +116,7 @@ The page's data will automatically refresh over time, but you may also manually 
 The `Ship Confirmation (ASN)` page is used for configuring the shipment interactions between Plentymarkets, the Wayfair Plugin, and Wayfair.
 The information set here will inform the `Send Ship Confirmation (ASN) to Wayfair` Order Procedure that the Wayfair Plugin provides.
 
-### Shipping type radio button
+### Shipping type
 The radio button at the top of the page has these options.
 During Wayfair plugin onboarding, Wayfair will instruct on which option is appropriate for the Plentymarkets user.
 * `Wayfair shipping`

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -2,6 +2,7 @@
 The Wayfair plugin comes with a collection of settings for controlling the plugin's behavior.
 These settings should only be configured after the authorization settings for the plugin have been configured in the active Plugin Set.
 
+# Opening the settings page
 To locate the settings:
 1. Log in to Plentymarkets as a user with administrative rights
 2. Click `Setup` in the top navigation bar of Plentymarkets
@@ -9,6 +10,9 @@ To locate the settings:
 4. Click `Wayfair` in the list of `Markets`. It may appear at the bottom, rather than being alphabetically situated.
 5. Click `Home` under `Wayfair`
 6. You may now use the Wayfair navigation bar to choose a settings page such as [`Warehouses`](#warehouses-page).
+
+# Home page
+The `Home` page is activated by clicking `Home` in the left-side menu or by clicking `Wayfair` in the Wayfair navigation bar. Currently, it provides no information.
 
 ## Warehouses page
 The Warehouses page is used for associating the Warehouses that the supplier is using in Plentymarkets with the Wayfair Supplier IDs that have been issued to the supplier. The mappings are utilized by the Wayfair plugin when it reports inventory to Wayfair and also when it is processing Wayfair orders coming into Plentymarkets.

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -102,6 +102,8 @@ The `Full Inventory` page does not contain any settings to configure.
 It is used for checking the status of syncing the Plentymarkets inventory with Wayfair, or manually initiating a synchronization of all inventory items.
 The page's data will automatically refresh over time, but you may also manually refresh it.
 
+**The Wayfair plugin periodically sends inventory updates to Wayfair, without any further manual activations. The Full Inventory page only displays information about the daily updates that include all items in the inventory.**
+
 ### Fields
 * The `Time of last successful inventory synchronization` fields keep track of the daily synchronizations that are normally preformed automatically.
     * A "check mark" icon will appear if it has been less than 24 hours since the last successful synchronization. This indicates that no actions are required.

--- a/meta/documents/user_guide/en/settings_guide.md
+++ b/meta/documents/user_guide/en/settings_guide.md
@@ -80,7 +80,7 @@ When the `Item Mapping Method` is set to `SKU`, each Item Variation in Plentymar
 
 3. **For each Item**, click on the item in the search results, then click `Variations`
 
-3. **For each Variation**:
+4. **For each Variation**:
     1. Click on the `Availability` tab
     2. In the `SKU` section, click the `Add` button
     3. In the pop-up window, choose `Wayfair` for the `Referrer` then enter the Wayfair Supplier Part Number in the `SKU` field, then click `Add`

--- a/meta/documents/user_guide/en/test_mode.md
+++ b/meta/documents/user_guide/en/test_mode.md
@@ -1,3 +1,21 @@
 # Wayfair plugin: Using the Test mode
 
-**TODO: complete**
+## Introduction
+The Wayfair plugin comes with a `Test` mode for use in evaluating its features without impacting live production data in Wayfair's systems. **The `Mode` setting, just like the API credentials, applies separately to each Plugin Set in Plentymarkets.**
+
+**IMPORTANT: This setting does not change the way that Plentymarkets operates, meaning Order information may differ between Plentymarkets's systems and Wayfair's systems.**
+
+## Enabling Test mode
+
+1. If your organization does not have any **Wayfair API Sandbox** applications, create a new one. The procedure matches [the instructions provided for obtaining credentials], except that the slider switch in the creation dialog should be left in the `Sandbox` position.  You may discard the credentials for the new Sandbox application. The Wayfair plugin must continue to use its Production credentials for proper functionality, even in `Test` mode.
+
+2. In the [Global Settings for the Wayfair plugin](initial_setup.md#1-authorizing-the-wayfair-plugin-to-access-wayfair-interfaces) in the active Plugin Set, use the `Mode` setting selector to set it to `Test`
+
+3. Save the Global Settings for the Wayfair plugin
+
+4. Log out of Plentymarkets and Log back in, to ensure that the settings take effect.
+
+## Technical details
+* When using `Test` mode, an interaction with Wayfair that would normally change the state of Wayfair order data is requested with a `dryMode` flag, which instructs Wayfair's systems to avoid changing state while processing the request.
+
+* **Though the `Test` mode does not currently use the Wayfair API Sandbox, changes to API Sandbox data may impact the behavior the Wayfiar plugin when it is in `Test` mode.**

--- a/meta/documents/user_guide/en/test_mode.md
+++ b/meta/documents/user_guide/en/test_mode.md
@@ -7,7 +7,7 @@ The Wayfair plugin comes with a `Test` mode for use in evaluating its features w
 
 ## Enabling Test mode
 
-1. If your organization does not have any **Wayfair API Sandbox** applications, create a new one. The procedure matches [the instructions provided for obtaining credentials], except that the slider switch in the creation dialog should be left in the `Sandbox` position.  You may discard the credentials for the new Sandbox application. The Wayfair plugin must continue to use its Production credentials for proper functionality, even in `Test` mode.
+1. If your organization does not have any **Wayfair API Sandbox** applications, create a new one. The procedure matches [the instructions provided for obtaining credentials](obtaining_credentials.md), except that the slider switch in the creation dialog should be left in the `Sandbox` position.  You may discard the credentials for the new Sandbox application. The Wayfair plugin must continue to use its Production credentials for proper functionality, even in `Test` mode.
 
 2. In the [Global Settings for the Wayfair plugin](initial_setup.md#1-authorizing-the-wayfair-plugin-to-access-wayfair-interfaces) in the active Plugin Set, use the `Mode` setting selector to set it to `Test`
 
@@ -18,4 +18,4 @@ The Wayfair plugin comes with a `Test` mode for use in evaluating its features w
 ## Technical details
 * When using `Test` mode, an interaction with Wayfair that would normally change the state of Wayfair order data is requested with a `dryMode` flag, which instructs Wayfair's systems to avoid changing state while processing the request.
 
-* **Though the `Test` mode does not currently use the Wayfair API Sandbox, changes to API Sandbox data may impact the behavior the Wayfiar plugin when it is in `Test` mode.**
+* **Though the `Test` mode does not currently use the Wayfair API Sandbox, changes to API Sandbox data may impact the behavior of the Wayfair plugin when it is in `Test` mode.**

--- a/meta/documents/user_guide/en/test_mode.md
+++ b/meta/documents/user_guide/en/test_mode.md
@@ -1,0 +1,3 @@
+# Wayfair plugin: Using the Test mode
+
+**TODO: complete**

--- a/meta/documents/user_guide/en/tips_and_tricks.md
+++ b/meta/documents/user_guide/en/tips_and_tricks.md
@@ -1,5 +1,8 @@
+# Wayfair plugin: Tips and Tricks
 
-### Protecting your credentials
+This document contains tips and ideas regarding use of the Wayfair plugin.
+
+## Protecting your credentials
 The credentials that your Plentymarkets system uses for communication with Wayfair should not be shared with anyone. You should take care to avoid doing these things:
 
 * Forwarding Wayfair emails

--- a/meta/documents/user_guide/en/tips_and_tricks.md
+++ b/meta/documents/user_guide/en/tips_and_tricks.md
@@ -5,6 +5,6 @@ This document contains tips and ideas regarding use of the Wayfair plugin.
 ## Protecting your credentials
 The credentials that your Plentymarkets system uses for communication with Wayfair should not be shared with anyone. You should take care to avoid doing these things:
 
-* Forwarding Wayfair emails
+* Forwarding communications from Wayfair concerning use of the Wayfair plugin to others
 * Sharing screenshots of the Global Settings for the Wayfair plugin
 * Exporting the configuration of a Plugin Set that contains the Wayfair plugin

--- a/meta/documents/user_guide/en/tips_and_tricks.md
+++ b/meta/documents/user_guide/en/tips_and_tricks.md
@@ -1,0 +1,7 @@
+
+### Protecting your credentials
+The credentials that your Plentymarkets system uses for communication with Wayfair should not be shared with anyone. You should take care to avoid doing these things:
+
+* Forwarding Wayfair emails
+* Sharing screenshots of the Global Settings for the Wayfair plugin
+* Exporting the configuration of a Plugin Set that contains the Wayfair plugin

--- a/meta/documents/user_guide/en/updating.md
+++ b/meta/documents/user_guide/en/updating.md
@@ -1,0 +1,42 @@
+# Wayfair plugin: Updating
+
+## Introduction
+The Wayfair plugin may be updated at any time to ensure that it is providing the best possible experience for suppliers. **Plentymarkets does not automatically update the Wayfair plugin for users**, so suppliers must manually update when it is desired.
+
+Prior to updating, review [the latest information on the Wayfair plugin's releases.](https://github.com/wayfair-contribs/plentymarkets-plugin/releases)
+
+## Updating to the latest version of the Wayfair Plugin
+1. From the main Plentymarkets page, go to `Plugins` >> `Plugin set overview`
+    * **Do not select the deprecated, similarly named `Plugin overview` option, if it appears in the menu.**
+
+    * The screen should show a list of plugin sets, with a set of buttons for each one.
+
+2. Locate the Plugin Set where the Wayfair plugin is installed.
+
+    * The list of plugins for the Plugin Set are hidden behind the `Edit plugin set` button.
+
+3. Click the `Edit plugin set` button for the Plugin Set.
+
+4. Verify that a row exists on the page with the `Name` displayed as "Wayfair" and that the `Deployed` column is also populated, indicating that the plugin is in use.
+
+5. Hover over the `Update` button in the `Actions` column
+
+5. If the button displays a `No update available` message, you already have the latest version of the Wayfair plugin. **Do not continue with this guide.** Otherwise, it should show `Update available` and a version number.
+
+6. Click the `Update` button. A page will be presented that has the Wayfair logo, information about the Wayfair plugin, and a new, different `Update` button at the top.
+
+7. Review the information on the page.
+
+9. In the `Select version` drop-down menu, choose [the newest plugin version](https://github.com/wayfair-contribs/plentymarkets-plugin/releases) if it is not already selected.
+
+10. Click the `Update` button at the top of the page. After a short pause, you will be redirected to the individual Plugin Set's details.
+
+11. Verify that a row exists on the page with the `Name` displayed as "Wayfair" and the `Installed` version showing as the desired version
+
+12. In the `Active` column for the "Wayfair" row, activate the switch so that it is in the right-side, enabled position. **Failure to activate the Wayfair plugin will prevent its functionalities from being available**.
+
+13. Click the `Deploy plugin set` button (appears as a Save button) at the top of the page. A progress bar will appear while the plugin is installed.
+
+14. Confirm that the `Deployed` column for the "Wayfair" row is now populated, and it reflects the value in the `Installed` column.
+
+15. Log out of the Plentymarkets system, then log back in, to ensure that the changes are now in effect.

--- a/meta/documents/user_guide/en/wayfair_shipping.md
+++ b/meta/documents/user_guide/en/wayfair_shipping.md
@@ -1,0 +1,85 @@
+# Wayfair plugin: Using Wayfair's Shipping Account
+
+## Introduction
+
+### WayfairShipping Shipping Service Provider Type
+The Wayfair plugin provides a type for Plentymarkets Shipping Service Provider Objects. The provider type does not have any configurable settings. Your Wayfair API credentials will be used to perform shipping-related operations.
+
+### Shipping on Wayfair's Account
+Wayfair's supplier partners may ship items using their preferred provider, but they also have the option of using Wayfair's shipment providers. This document covers the steps required for setting up Plentymarkets to use the "ship on Wayfair's account" option.
+
+
+## 1. Creating the Shipping Service Provider
+In order to create a Shipping Profile to be used for Orders, a Shipping Service Provider object must first be set up, which associates the Shipping Profile with a carrier. Follow these steps to create the Wayfair-specific Shipping Service Provider:
+
+1. From the main Plentymarkets page, go to `Setup` >> `Orders` >> `Shipping` >> `Settings`
+
+2. Select the `Shipping service Provider` tab
+
+3. Click the `New` button to add a new row to the table
+
+4. In the new row that is created, populate the `Name` fields (we recommend **"WayfairShipping"** for all names, for simplicity's sake).
+
+5. In the `Shipping service provider` field for the row, choose the `WayfairShipping` option - this reflects the type that is provided by the Wayfair plugin.
+
+6. You may leave all other fields on the row blank
+
+7. Click `Save`.
+
+## 2. Creating the Shipping Profile
+Each order has a Shipping Profile that is used for working with the shipping service provider to ship items from an order. Use these steps to set up the Wayfair-specific Shipping Profile.
+
+1. From the main Plentymarkets page, go to `Setup` >> `Orders` >> `Shipping` >> `Settings`
+
+2. Select the `Shipping profiles` tab
+
+3. If a Wayfair row already exists, click that row. Otherwise, click the `New` button. The Shipping Profile's settings will appear.
+
+4. Select your Wayfair `Shipping service provider` from the menu provided (it will likely be **"WayfairShipping"** if you have created [the suggested Shipping Service Provider](#1-creating-the-shipping-service-provider).
+
+5. Populate the `Name` fields (we recommend **"WayfairShipping"** for all names, for simplicity's sake).
+
+6. Set the language using the menu to the right of the `Name` field.
+
+7. In the `Flag` field, choose the icon that will represent Wayfair orders (`6` and `126` are good options, as they reflect the Wayfair color scheme).
+
+8. In the `Priority` field, optionally change the priority (we recommend leaving it as the default, "highest" priority).
+
+9. In the `Order referrer` list, place a check mark next to any **Wayfair**-related entries.
+
+10. Click on the `Save` button at the top of the page.
+
+
+## 3. Optionally selecting the Wayfair Shipping Profile automatically for Wayfair orders
+
+1. From the main Plentymarkets page, go to  `Setup` >> `Orders` >> `Events`
+
+2. Click on `Add event procedure` (the `+` button on the bottom of the left side of the page) to launch the `Create new event procedure` dialog
+
+3. Enter a `Name` such as **"Wayfair order Shipping Mapping"**.
+
+4. Select the event `New order` from the dropdown menu.
+
+5. Click the `Save` button on the dialog. The new procedure will now be selected, with the `Settings` section in view.
+
+6. In the `Settings` section of the event procedure, check the `Active` checkbox.
+
+7. Click the ``Add filter`` button (the `+` button at the top of the `Filter` section), to launch the `Add filter` dialog.
+
+8. Select  `Order` >> `Referrer`
+
+9. Click the `Add` button to complete the dialog. A `Referrer` filter will now appear on the form.
+
+10. In the `Referrer` list, activate the checkbox for all **Wayfair**-related Order Referrers
+
+11. Click the `Add procedure` button (the `+` button at the top of the `Procedures` section) to launch the `Add procedure` dialog.
+
+12. Select `Order` >> `Change shipping profile`.
+
+13. Click the `Add` button to complete the dialog. A `Change shipping profile` Procedure will appear in the `Procedures` area.
+
+12. Click on the left-most `^` (carat) icon on the left of the `Change shipping profile` Procedure's row **(this is NOT the large square button that also happens to have a carat icon on it)** to expand the Procedure's details.
+
+13. In the drop-down menu on the Procedure, choose the [Shipping Profile created for WayfairShipping](#2-creating-the-shipping-profile).
+
+14. Click the `Save` button at the top of the page to complete the creation of the Event Procedure.

--- a/meta/documents/user_guide_en.md
+++ b/meta/documents/user_guide_en.md
@@ -1,293 +1,38 @@
 # Wayfair plugin user guide
 <div class="container-toc"></div>
 
-## 1. Registering with Wayfair
-Wayfair is a closed marketplace. In order to use this plugin, you have to be a registered supplier with Wayfair.
+To ensure that you are viewing the latest version of this document, [click here](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide_en.md).
 
-Please send us an email to ERPSupport@wayfair.com
+## Welcome to Wayfair
+Wayfair is a closed marketplace. Use of the Wayfair plugin is limited to organizations that have registered as Wayfair suppliers.
 
-**Notice (March 2020):** This is a new email address for Wayfair. Please update the email you have on file.
+If you are not yet working with Wayfair, please send an email to ERPSupport@wayfair.com to get more information.
 
-After you have successfully registered as a supplier on Wayfair, you will have to go through the standard instructions seen below.
+## Introduction to the Wayfair plugin
+The Wayfair plugin is the official plugin for using Plentymarkets to sell items on the Wayfair marketplace.
+The plugin provides multiple integrations with Wayfair's interfaces, including - but not limited to - the following operations:
+* Automatic retrieval of Wayfair orders, with conversion to Plentymarkets orders
+* Automatic sending of Plentymarkets inventory information to Wayfair, to keep item availability accurate
+* Automatic transferal of Wayfair-generated shipping documents to Plentymarkets
+* Sending order status changes from Plentymarkets to Wayfair, to keep Wayfair customers and Wayfair Customer Support up to date.
 
-The installation of the Wayfair plugin allows for the following automatic processes to take place:
+## Preparing to use the Wayfair plugin
+Use of the Wayfair plugin requires Wayfair API credentials that have been granted the appropriate rights.
 
-- periodic order import
-- periodic stock synchronization
+Prior to installation, please use [these instructions](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/obtaining_credentials.md) to contact Wayfair and obtain proper API credentials.
 
+## Installing the Wayfair plugin
+The Wayfair plugin is available for free on the PlentyMarketplace. [Click here](https://marketplace.plentymarkets.com/en/plugins/integration/wayfair_6273) to view the plugin's page.
 
-## 2. Retrieving your credentials
+Install the plugin into the active Plugin Set in Plentymarkets. For guided instructions from Wayfair, [click here](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/plugin_installation.md).
 
-In order to connect Wayfair to Plentymarkets, you need to enter API credentials. To receive them, you must first send an email to ERPSupport@wayfair.com and provide the following information:
 
-- Subject : Access to Plentymarkets plugin / "Name of your company" (SuID)
-- Information contact
-- Which functionalities you plan to use.
+## Setting up the Wayfair plugin
+Prior to first use of the plugin, [use these instructions](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/initial_setup.md) to get the plugin properly connected to Wayfair and functioning as desired.
 
-You will shortly receive an email back, containing a confirmation that you have been granted access to the API tools, as well as your **Supplier ID(s)**. Next, you need to head over to your Extranet account at partners.wayfair.com. In the banner, you should see a tab named "Developer". If you don’t see it in the banner, then hover over the "More" tab, and it should appear in the dropdown menu.
-
-Hover over the "Developer" tab, and click on "Application". You should be redirected to a new page. On this new page, click on the button named " + New Application", and give a name and description to your application
-
-Click on "Save", then you should be shown a ClientID and Client Secret, which are the credentials you will need to use for the Wayfair plugin. Save these somewhere secure, especially the Client Secret, as you will only be able to see it once.
-
-## 3. Installing the Wayfair plugin in Plentymarkets
-
-1. Login to the Plentymarkets system
-
-2. Go to **plugins >> plentyMarketplace**, which will use the system owner’s credentials to log you in on the Marketplace
-
-3. Click the search button  in the top-right corner of the page
-
-4. Enter “Wayfair” into the box and press enter
-
-5. If “Already purchased” appears on the page, skip to step 8
-
-6. Click the **go to checkout** button
-7. Complete the purchasing form
-    1. Accept terms and conditions
-    2. Click **order now**
-
-8. Return to the Plentymarkets system, and go to **Plugins >> Plugin Overview**.
-
-9. Find/Create a Plugin Set where the plugin is to be installed - the proper plugin set will be marked as **Linked to** your "shop."
-
-10. Un-check the **installed** checkbox
-
-11. Check the **plentyMarketplace** checkbox
-
-12. Type “Wayfair” into the **name** field
-
-13. Click **search** to find the appropriate plugin - only one should appear, with the marketplace icon in the Source column.
-
-14. Click the **install** button in the Wayfair row
-
-15. Complete the pop-up modal
-    1. (Optional) in the drop-down, choose a different version to install - you probably should be using the newest one.
-
-    2. Click **install**
-
-16. Refresh the Plugin Overview page
-
-17. Click on the name of the plugin set where the plugin was installed
-
-18. Click the **Activate** button in the Wayfair plugin row of the plugin set
-
-19. Click the save icon  above the list, and wait for the progress bar to complete. A timestamp will display at successful completion.
-
-20. If an error symbol appears, check the Plentymarkets logs for plugin build and deployment failures
-
-
-### Authorizing the Plugin to access the Wayfair interfaces
-After the plugin is installed in your Plentymarkets system, enter the application credentials required for accessing Wayfair:
-
-1. Go to **Plugins >> Plugin Overview**
-
-2. Select the plugin set that contains the Wayfair plugin
-
-3. Click on the "Wayfair " name in the plugin set details
-
-4. Go to **Configuration >> Global Settings**
-
-5. Enter the Client ID and Client Secret you received when creating the application in Extranet into the fields **Client ID** and **Client Secret**.
-
-6. Change **Mode** to **Live**.
-7. **Save** the settings.
-
-## 4. Activating the order referrer
-
-An order referrer indicates the sales channel on which an order was generated. You have to activate the Wayfair order referrer in order to link items, properties etc. with Wayfair.
-
-### Activating the order referrer for Wayfair:
-
-1. Go to **System >> Orders >> Order referrer**.
-
-2. Place a check mark next to the **Wayfair** order referrer.
-
-3. Click on **Save**.
-
-## 5. Making an item available for Wayfair.
-
-Items that you want to sell on the Wayfair website have to be active and available for Wayfair. These settings are carried out in the **Item >> Edit item >> Open item>> Tab: Variation ID**. Please keep in mind that you have to carry out these settings for all the items that you wish to sell on Wayfair.
-
-### Setting the item availability for Wayfair:
-
-1. Go to **Item >> Edit Item** then click on the **Item ID** of the item that you wish to make available for Wayfair.
-
-2. You will be redirected to the **Settings** tab of the chosen item. In this tab, there is a section called **Availability**. Place a check mark next to the option **Active** in this section.
-
-3. Click on the tab **Availability**.
-
-4. Click in the selection field in the **Markets** section. A list with all available markets is displayed.
-
-5. Place a check mark next to the option **Wayfair**.
-
-6. Click on **Add**. The market is now added.
-
-7. Click on **Save**. The item is now available for Wayfair.
-
-### 6. Matching an incoming order with your items in Plentymarkets:
-In order to match an item in Wayfair's database, which is defined by the Supplier Part Number you have provided to Wayfair, with your items in Plentymarkets, you need to configure which Plentymarkets field the Wayfair Supplier Part Number should match with.
-
-To do so, follow the instructions below:
-
-1. Go to **Setup >> System >> Markets >> Wayfair >> Home**.
-
-2. Once the homepage of the plugin has loaded, click on **Settings**.
-
-3. Under **Item Mapping Method**, choose Plentymarkets field from which the Supplier Part Number you provided to Wayfair comes from. You can choose from these three fields:
-           **a.** *Variation No.*
-           **b.**  *EAN*
-           **c.** *Marketplace-specific SKU*: choose this option only if none of the two Plentymarkets fields above match with the Supplier Part Number you provided to Wayfair. If you choose this option, please follow the instructions below (Matching an incoming order using the marketplace-specific SKU).
-
-4. Click **Save**.
-
-#### Matching an incoming order using the marketplace-specific SKU.
-
-1. Go to **Item >> Edit Item** and click on the **Item ID** of the item that you wish to match with incoming Wayfair orders.
-
-2. You will be redirected to the **Settings** tab of the chosen item. Click on the tab **Availability**.
-
-3. In this tab, there are four different sections. The one that we want is the **SKU** section.
-
-4. Click on the **Add** button (the with cross in grey background)
-
-5. A new window will be opened. In the first field(**Referrer**), choose the **Wayfair** order referrer from the dropdown menu.
-
-6. In the third field (**SKU**), enter the **Supplier Part Number**.
-7. Click on **Add**.
-
-8. Click on **Save**.
-
-9. Repeat the same process for all items that you are selling on Wayfair.
-
-## Setting up the order fulfillment.
-
-A working order fulfillment with the Wayfair plugin requires to set up **Shipping Profile Mappings** and **Event Procedures**. Carry out the following instructions:
-
-### Create a new shipping service provider
-
-1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping service provider**
-
-2. Click on **+ New** in order to create a new **shipping service provider**.
-
-3. Enter **Wayfair Shipping** in the fields **Name (de)** and **Name (backend)**.
-
-4. Click in the field **Shipping service provider** and choose **WayfairShipping**.
-
-5. Click on **Save**.
-
-### Create a new shipping profile
-
-1. Go to **System >> Orders >> Shipping >> Settings >> Tab: Shipping Profiles**
-
-2. Click on **+ New** to create a new shipping profile.
-
-3. You will see a table in which you have to enter data.
-
-4. In the first row, click on the dropdown menu, and choose the *Shipping service provider** you have just created (should be **WayfairShipping** if you followed our instructions)
-
-5. In the second and third row, enter a name (we recommend **WayfairShipping** for simplicity). You should also choose a language in the second row, third column.
-
-6. In the fourth row, choose the flag number 6 or 126 (which represent the Wayfair colors).
-
-7. In the fifth column, choose **priority n1** (the two stars).
-
-8. In the seventeenth column (**Order referrer**), place a check mark next to **Wayfair** (if there are more than one, choose all).
-
-9. Scroll to the top of the page, and click on the **save** button. All the other rows and their respective data entries can be left empty.
-
-### Creating a new event procedure
-
-
-1. Go to **System >> Orders >> Events**
-
-2. Click on **Add event procedure** (the "+" button on the left of the page).
-
-3. Enter the name **Wayfair order Shipping Mapping**.
-
-4. Select the event **New order** from the dropdown menu.
-
-5. Click on the **save** button.
-
-6. You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a check mark next to **Active**.
-
-7. Click on **Add filter**, and go to **Order >> Referrer** to add the referrer as a filter.
-
-8. In the **Filter** section, a box should appear with a list of all available **Order referrers**. Place a check mark next to all **Wayfair** order referrers.
-
-9. Click on **Add procedure**, and go to **Order >> Change shipping profile**. Click on **+ add**.
-
-10. In the **Procedures** section, click on the **expand** button next to **change shipping profile** (left-most arrow).
-
-11. Choose the **shipping profile** you created before (should be **WayfairShipping** if you followed our instructions).
-
-12. Click on the **save** button.
-
-## 7. Configuring the warehouse mapping.
-
-In order to update the inventory data in Wayfair's system, you need to map the warehouse ID's in your Plentymarkets system to the warehouse ID in Wayfair's system.
-
-1. Go to **System >> Markets >> Wayfair >> Home >> Tab: Warehouses**
-
-2. Click on **Add mapping**
-
-3. In the field **Warehouse** select the warehouse you want to map.
-
-4. In the field **Supplier ID**, enter your corresponding Wayfair Supplier ID.
-
-5. Click on **Save**
-
-## 8. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
-
-### Update Settings for carrier if shipping on own account
-
-![Select shipping method](https://i.ibb.co/5L6pxpk/asn-01.png "Select shipping method")
-
-1.	Select **Systems >> Markets >> Wayfair >> Home**
-
-2.	Then select **Ship Confirmation (ASN)** and select either **Wayfair Shipping** or **Own account Shipping** depending on how your logistics setup is with Wayfair (If you are not sure, reach out to your Wayfair contact).
-
-3.	Next, enter then **SCAC codes** provided by Wayfair during the onboarding interview for each of the carriers you ship Wayfair orders with.
-
-### Create Event and bind to WayFair plugin for Sending Shipment Notification
-
-1. Click **Setup** in the top navigation bar then go to **Orders >> Events**
-![Create Event](https://i.ibb.co/NjDtY05/asn-02.png "Create Event")
-
-2.	Click on **Add event procedure** (the "+" button on the left of the page)
-
-3.	Enter any **Name**
-
-4.	Select **Status change** (in the category **Order Change**) in the **Event** field.
-
-5.	In the field below **Event** select the status change that should initiate the sending of an ASN to Wayfair, such as **in preparation for shipping**.
-
-6.	Click the **Save** button.
-
-7.	You should automatically be redirected to the newly created **event procedure**. In the **settings** section of the event procedure, place a checkmark next to **Active**.
-
-8.  Click on **Add Filter**, and go to **Order >> Referrer** to add the referrer as a filter (see screenshot below)
-![Event Referrer](https://i.ibb.co/TwKLvJ5/asn-03.png "Event Referrer")
-
-9.	In the **Filter** section, a box should appear with a list of all available Order referrers. Place a checkmark next to all **Wayfair** order referrers.
-![Wayfair Referrer](https://i.ibb.co/yYpLp8q/asn-04.png "Wayfair Referrer")
-
-10. Click on **Add procedure**, and go to **Plugins >> Send Ship Confirmation (ASN) to Wayfair**. Click on **+ add**.
-![Add Procedure](https://i.ibb.co/xfGrhFP/asn-05.png "Add Procedure")
-
-The final settings result should look similar to this:
-![Add Procedure Result](https://i.ibb.co/GJPF3ZV/asn-06.png "Add Procedure Result")
-
-
-## 9. Customizing and monitoring
+## Customization and monitoring
 The Wayfair plugin presents Plentymarkets users with the ability to customize and monitor its behavior.
 [Click here to view the latest instructions](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md).
 
 ## Tips and tricks
-
-### Protecting your credentials
-The credentials that your Plentymarkets system uses for communication with Wayfair should not be shared with anyone. You should take care to avoid doing these things:
-
-* Forwarding Wayfair emails
-* Sharing screenshots of the Global Settings for the Wayfair plugin
-* Exporting the configuration of a Plugin Set that contains the Wayfair plugin
+Things are always changing at Plentymarkets as well as at Wayfair. [Click here for information on using the Wayfair plugin efficiently and securely](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/tips_and_tricks.md).

--- a/meta/documents/user_guide_en.md
+++ b/meta/documents/user_guide_en.md
@@ -3,18 +3,24 @@
 
 To ensure that you are viewing the latest version of this document, [click here](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide_en.md).
 
+
 ## Welcome to Wayfair
-Wayfair is a closed marketplace. Use of the Wayfair plugin is limited to organizations that have registered as Wayfair suppliers.
 
-If you are not yet working with Wayfair, please send an email to ERPSupport@wayfair.com to get more information.
-
-## Introduction to the Wayfair plugin
+### Introduction to the Wayfair plugin
 The Wayfair plugin is the official plugin for using Plentymarkets to sell items on the Wayfair marketplace.
 The plugin provides multiple integrations with Wayfair's interfaces, including - but not limited to - the following operations:
 * Automatic retrieval of Wayfair orders, with conversion to Plentymarkets orders
 * Automatic sending of Plentymarkets inventory information to Wayfair, to keep item availability accurate
 * Automatic transferal of Wayfair-generated shipping documents to Plentymarkets
 * Sending order status changes from Plentymarkets to Wayfair, to keep Wayfair customers and Wayfair Customer Support up to date.
+
+### Selling on Wayfair
+Wayfair is a closed marketplace. Use of the Wayfair plugin is limited to organizations that have registered as Wayfair suppliers.
+
+If you are not currently selling on Wayfair, please go to https://partners.wayfair.com/d/onboarding/sell-on-wayfair to get started.
+
+### Instructions for current Wayfair suppliers
+If you are a Wayfair supplier looking to use the Wayfair Plentymarkets plugin, please review [the prerequisites for use of the plugin](#preparing-to-use-the-wayfair-plugin) to learn how to make the proper arrangements with your Wayfair Account Manager.
 
 ## Preparing to use the Wayfair plugin
 Use of the Wayfair plugin requires Wayfair API credentials that have been granted the appropriate rights.

--- a/meta/documents/user_guide_en.md
+++ b/meta/documents/user_guide_en.md
@@ -36,6 +36,9 @@ Install the plugin into the active Plugin Set in Plentymarkets. For guided instr
 ## Setting up the Wayfair plugin
 Prior to first use of the plugin, [use these instructions](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/initial_setup.md) to get the plugin properly connected to Wayfair and functioning as desired.
 
+## Updating the Wayfair plugin
+Wayfair may occasionally release free updates for the Wayfair plugin. [Click here for information on checking for updates and installing them](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/updating.md).
+
 ## Customization and monitoring
 The Wayfair plugin presents Plentymarkets users with the ability to customize and monitor its behavior.
 [Click here to view the latest instructions](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md).


### PR DESCRIPTION
Making the User Guide that shows up on the PlentyMarketplace something that's enjoyable and easy to read.

**Notices:**
- The link at the top points to the `master` branch version of this document, so that people reading stale versions on the PlentyMarketplace can come read the current information
- **We will be adding screenshots to the documentation in future Pull Requests, and suppliers will see them because they'll be reading the docs on GitHub, not on Plentymarkets!!!**
- We must use Fully-Qualified URLs for images and links in `meta/documents/user_guide_en.md`, because the PlentyMarketplace copies ONLY the `meta/documents/user_guide_en.md` file and the other documents and images do not get hosted there. 
- Most of the links in the main document will NOT work until this PR gets merged, as they point to the upcoming `master` branch versions of the new documents.
- The German user guide will be updated to reflect this model once we obtain sign-off on all English text, as the German stuff must be properly translated.

**Goals:**
- Make the user guide smaller overall
- Add non-robotic "welcome" and "how to get started" blurbs
- Remove most static info from the User guide, so that we can change things without pushing the user guide to the plentyMarketplace
- Add and polish the sub-pages that we are now linking out to.
- Instruct users to use the Plentymarkets `Plugin set overview` UX now that the old `Plugin set` UX is deprecated