### PR TITLE
bump plugin version to 1.1.3-alpha

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wayfair-plugin",
-	"version": "1.1.2",
+	"version": "1.1.3-alpha",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/angular/package.json
+++ b/angular/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wayfair-plugin",
-	"version": "1.1.2",
+	"version": "1.1.3-alpha",
 	"license": "SEE LICENSE at https://raw.githubusercontent.com/wayfair-contribs/plentymarkets-plugin/master/LICENSE.md",
 	"scripts": {
 		"server:dev": "webpack-dev-server --config config/webpack.dev.js --progress --profile --watch",

--- a/angular/src/app/assets/lang/locale-de.json
+++ b/angular/src/app/assets/lang/locale-de.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.2",
+  "plugin_version": "Wayfair plugin v1.1.3-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - Alle Rechte vorbehalten",
   "welcomeMessage": "Willkommen bei Wayfair",
   "warehouse_menu": "Lager",

--- a/angular/src/app/assets/lang/locale-en.json
+++ b/angular/src/app/assets/lang/locale-en.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.2",
+  "plugin_version": "Wayfair plugin v1.1.3-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - All rights reserved",
   "welcomeMessage": "Welcome to Wayfair",
   "warehouse_menu": "Warehouses",

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
       "email": "ERPSupport@wayfair.com",
       "authorIcon": "icon_author_xs.png",
       "type": "shipping",
-      "version": "1.1.2",
+      "version": "1.1.3-alpha",
       "pluginIcon": "icon_plugin_md.png",
       "categories": ["3521"],
       "price": 0.00,

--- a/ui/assets/lang/locale-de.json
+++ b/ui/assets/lang/locale-de.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.2",
+  "plugin_version": "Wayfair plugin v1.1.3-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - Alle Rechte vorbehalten",
   "welcomeMessage": "Willkommen bei Wayfair",
   "warehouse_menu": "Lager",

--- a/ui/assets/lang/locale-en.json
+++ b/ui/assets/lang/locale-en.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.2",
+  "plugin_version": "Wayfair plugin v1.1.3-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - All rights reserved",
   "welcomeMessage": "Welcome to Wayfair",
   "warehouse_menu": "Warehouses",


### PR DESCRIPTION
Now that `release-1.1.2` is branched off of `master`, the `master` branch should be considered `1.1.3-alpha`