### PR TITLE
use a relative link to settings page

### DIFF
--- a/meta/documents/user_guide/en/initial_setup.md
+++ b/meta/documents/user_guide/en/initial_setup.md
@@ -85,7 +85,7 @@ In order to update the inventory data in Wayfair's system, you need to map the W
 ## 7. Configuring Plentymarkets to send Confirmation of Delivery (ASN) to Wayfair
 
 ### 7.1 Setting the Wayfair Plugin to send the correct shipping information to Wayfair
-Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update the [Ship Confirmation (ASN) configuration settings](https://github.com/wayfair-contribs/plentymarkets-plugin/blob/master/meta/documents/user_guide/en/settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
+Wayfair Plugin users that wish to ship orders by using their own accounts (rather than using Wayfair's shipping services) must update the [Ship Confirmation (ASN) configuration settings](settings_guide.md#ship-confirmation-asn-page) to reflect their specific configuration.
 
 If Wayfair's shipping services are to be used, the Wayfair plugin's ASN settings should be left in their default (`Wayfair Shipping`) state.
 


### PR DESCRIPTION
the initial setup document was using a Fully-Qualified link instead of a relative link, but the context does not require the Fully-Qualified link.