### PR TITLE
set main branch version identifier to be 1.1.4-alpha

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wayfair-plugin",
-	"version": "1.1.3-alpha",
+	"version": "1.1.4-alpha",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/angular/package.json
+++ b/angular/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wayfair-plugin",
-	"version": "1.1.3-alpha",
+	"version": "1.1.4-alpha",
 	"license": "SEE LICENSE at https://raw.githubusercontent.com/wayfair-contribs/plentymarkets-plugin/main/LICENSE.md",
 	"scripts": {
 		"server:dev": "webpack-dev-server --config config/webpack.dev.js --progress --profile --watch",

--- a/angular/src/app/assets/lang/locale-de.json
+++ b/angular/src/app/assets/lang/locale-de.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.3-alpha",
+  "plugin_version": "Wayfair plugin v1.1.4-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - Alle Rechte vorbehalten",
   "welcomeMessage": "Willkommen bei Wayfair",
   "warehouse_menu": "Lager",

--- a/angular/src/app/assets/lang/locale-en.json
+++ b/angular/src/app/assets/lang/locale-en.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.3-alpha",
+  "plugin_version": "Wayfair plugin v1.1.4-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - All rights reserved",
   "welcomeMessage": "Welcome to Wayfair",
   "warehouse_menu": "Warehouses",

--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,8 @@
 ﻿# Versionshinweise für Wayfair
 
+## v1.1.3 (2020-08-04)
+- Informationen finden Sie unter diesem Link: https://github.com/wayfair-contribs/plentymarkets-plugin/releases/tag/v1.1.3
+
 ## v1.1.2 (2020-07-17)
 - Informationen finden Sie unter diesem Link: https://github.com/wayfair-contribs/plentymarkets-plugin/releases/tag/v1.1.2
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,8 @@
 ﻿# Release notes for Wayfair
 
+## v1.1.3 (2020-08-04)
+- see https://github.com/wayfair-contribs/plentymarkets-plugin/releases/tag/v1.1.3
+
 ## v1.1.2 (2020-07-17)
 - see https://github.com/wayfair-contribs/plentymarkets-plugin/releases/tag/v1.1.2
 

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
       "email": "ERPSupport@wayfair.com",
       "authorIcon": "icon_author_xs.png",
       "type": "shipping",
-      "version": "1.1.3-alpha",
+      "version": "1.1.4-alpha",
       "pluginIcon": "icon_plugin_md.png",
       "categories": ["3521"],
       "price": 0.00,

--- a/ui/assets/lang/locale-de.json
+++ b/ui/assets/lang/locale-de.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.3-alpha",
+  "plugin_version": "Wayfair plugin v1.1.4-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - Alle Rechte vorbehalten",
   "welcomeMessage": "Willkommen bei Wayfair",
   "warehouse_menu": "Lager",

--- a/ui/assets/lang/locale-en.json
+++ b/ui/assets/lang/locale-en.json
@@ -1,5 +1,5 @@
 {
-  "plugin_version": "Wayfair plugin v1.1.3-alpha",
+  "plugin_version": "Wayfair plugin v1.1.4-alpha",
   "copyright_footer": "© Copyright 2020 Wayfair LLC - All rights reserved",
   "welcomeMessage": "Welcome to Wayfair",
   "warehouse_menu": "Warehouses",


### PR DESCRIPTION
As the `release-1.1.3` branch now exists, the `main` branch will report itself as version `1.1.4-alpha`.