### PR TITLE
avoid throwing exceptions for lack of packing slips

### DIFF
--- a/src/Services/CreateOrderService.php
+++ b/src/Services/CreateOrderService.php
@@ -6,7 +6,6 @@
 
 namespace Wayfair\Services;
 
-use Exception;
 use Plenty\Modules\Account\Address\Models\AddressRelationType;
 use Plenty\Modules\Account\Contact\Models\ContactType;
 use Plenty\Modules\Payment\Contracts\PaymentOrderRelationRepositoryContract;
@@ -337,7 +336,7 @@ class CreateOrderService
       try {
         $this->savePackingSlipService->save($orderId, $poNumber);
       } catch (\Exception $exception) {
-        $externalLogs->addErrorLog("Unexpected " . get_class($exception) . " while working with packing slips: " . $exception->getMessage())
+        $externalLogs->addErrorLog("Unexpected " . get_class($exception) . " while working with packing slips: " . $exception->getMessage());
       }
 
       return $orderId;

--- a/src/Services/CreateOrderService.php
+++ b/src/Services/CreateOrderService.php
@@ -238,7 +238,7 @@ class CreateOrderService
           $billing = \json_decode($encodedBillingContactFromRepository, true);
         } catch (\Exception $e) {
           $externalLogs->addWarningLog("Could not decode billing information in KeyValueRepository - "
-            . get_class($e) . ": " . $e->getMessage());
+            . get_class($e) . ": " . $e->getMessage(), $e->getTraceAsString());
         }
       }
 
@@ -336,7 +336,7 @@ class CreateOrderService
       try {
         $this->savePackingSlipService->save($orderId, $poNumber);
       } catch (\Exception $exception) {
-        $externalLogs->addErrorLog("Unexpected " . get_class($exception) . " while working with packing slips: " . $exception->getMessage());
+        $externalLogs->addErrorLog("Unexpected " . get_class($exception) . " while working with packing slips: " . $exception->getMessage(), $exception->getTraceAsString());
       }
 
       return $orderId;

--- a/src/Services/SavePackingSlipService.php
+++ b/src/Services/SavePackingSlipService.php
@@ -203,6 +203,7 @@ class SavePackingSlipService
 
       $upload_result = $this->documentRepositoryContract->uploadOrderDocuments($orderId, Document::DELIVERY_NOTE, $documentData);
 
+      // TODO: log ID of uploaded document, if any
       $this->loggerContract->debug(
         TranslationHelper::getLoggerKey(self::LOG_KEY_FINISHED_UPLOADING_ORDER_DOCUMENTS),
         [

--- a/src/Services/SavePackingSlipService.php
+++ b/src/Services/SavePackingSlipService.php
@@ -203,7 +203,6 @@ class SavePackingSlipService
 
       $upload_result = $this->documentRepositoryContract->uploadOrderDocuments($orderId, Document::DELIVERY_NOTE, $documentData);
 
-      // TODO: log ID of uploaded document, if any
       $this->loggerContract->debug(
         TranslationHelper::getLoggerKey(self::LOG_KEY_FINISHED_UPLOADING_ORDER_DOCUMENTS),
         [


### PR DESCRIPTION
- a lack of packing slip no longer throws an exception
- an order is no longer considered flawed due to lack of packing slip data - no longer will appear as "failed" in logs sent to Wayfair.