### PR TITLE
remove arg from tslint call so that it executes correctly

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -9,7 +9,7 @@
 		"clean:dist": "npm run rimraf -- ../ui",
 		"rimraf": "rimraf",
 		"test": "npm run lint",
-		"lint": "tslint --type-check -p tsconfig.json -c tslint.json 'src/**/*.ts'",
+		"lint": "tslint --type-check -p tsconfig.json -c tslint.json",
 		"reinstall": "rm -rf node_modules/ && npm i"
 	},
 	"private": true,


### PR DESCRIPTION
make typescript linting functional on Windows
There are MANY issues that appeared when the linter ran in linux, making the draft "build UI" GitHub action fail!