### PR TITLE
have GitHub rebuild the UI when needed

### DIFF
--- a/.github/workflows/build_ui.yml
+++ b/.github/workflows/build_ui.yml
@@ -1,0 +1,34 @@
+name: build-ui
+
+on:
+  push:
+    paths:
+      - "angular/**"
+      - "ui/**"
+  workflow_dispatch:
+
+jobs:
+  build-then-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup-node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: build-ui-with-npm
+        working-directory: ./angular
+        env:
+          CI: true
+        run: |
+          npm install
+          npm run build
+      - name: push-ui-changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "automated UI code generation via github action"
+          git push


### PR DESCRIPTION
When a developer pushes changes to the `angular` or `ui` directories, GitHub will rebuild the UI to make sure it is up to date, and automatically push a new commit.