### PR TITLE
improved UI Builder action

### DIFF
--- a/.github/workflows/build_ui.yml
+++ b/.github/workflows/build_ui.yml
@@ -25,8 +25,18 @@ jobs:
         run: |
           npm install
           npm run build
-      - name: push-ui-changes-if-branch-not-protected
-        if: false == (endsWith(github.ref, '/master') || endsWith(github.ref, '/main') || contains(github.ref, 'release-'))
+
+      - name: check_for_changed_files
+        run: echo "::set-output name=GIT_STATUS::$(git status -s)"
+
+      - name: fail-out-if-protected-branch-needs-UI-generation
+        if: (${{ steps.check_for_changed_files.outputs.GIT_STATUS }} != '' && (endsWith(github.ref, '/master') || endsWith(github.ref, '/main') || contains(github.ref, 'release-')))
+        run: |
+          echo "branch is protected - differences between Angular and UI must be resolved before pushing to a protected branch!"
+          exit 1
+
+      - name: push-ui-changes-if-present
+        if: ${{ steps.check_for_changed_files.outputs.GIT_STATUS }} != ''
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build_ui.yml
+++ b/.github/workflows/build_ui.yml
@@ -14,12 +14,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-
       - name: setup-node
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-
       - name: build-ui-with-npm
         working-directory: ./angular
         env:
@@ -28,17 +26,18 @@ jobs:
           npm install
           npm run build
 
-      - name: check_for_changed_files
+      - id: check_for_changed_files
+        name: check_for_changed_files
         run: echo "::set-output name=GIT_STATUS::$(git status -s)"
 
       - name: fail-out-if-protected-branch-needs-UI-generation
-        if: (${{ steps.check_for_changed_files.outputs.GIT_STATUS }} != '' && (endsWith(github.ref, '/master') || endsWith(github.ref, '/main') || contains(github.ref, 'release-')))
+        if: steps.check_for_changed_files.outputs.GIT_STATUS != '' && (endsWith(github.ref, '/master') || endsWith(github.ref, '/main') || contains(github.ref, 'release-'))
         run: |
           echo "branch is protected - differences between Angular and UI must be resolved before pushing to a protected branch!"
           exit 1
 
       - name: push-ui-changes-if-present
-        if: ${{ steps.check_for_changed_files.outputs.GIT_STATUS }} != ''
+        if: steps.check_for_changed_files.outputs.GIT_STATUS != ''
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build_ui.yml
+++ b/.github/workflows/build_ui.yml
@@ -14,10 +14,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+
       - name: setup-node
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
+
       - name: build-ui-with-npm
         working-directory: ./angular
         env:


### PR DESCRIPTION
- use `git status -s` to check if UI is up to date
- Fail out of the UI building action if there are changes to be made but the branch is protected (main, release, etc), because that means nobody has actually seen/tested the UI yet (and because the bot is not able to push the generated UI)