### PR TITLE
return the correct HTTP error codes for Inventory

### DIFF
--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -10,6 +10,7 @@ use Plenty\Plugin\Controller;
 use Plenty\Plugin\Http\Request;
 use Plenty\Plugin\Http\Response;
 use Wayfair\Core\Contracts\LoggerContract;
+use Wayfair\Core\Exceptions\AuthException;
 use Wayfair\Services\InventoryStatusService;
 use Wayfair\Services\InventoryUpdateService;
 use Wayfair\Helpers\TranslationHelper;
@@ -107,9 +108,10 @@ class InventoryController extends Controller
       ]);
 
       return $response->json($payloadOut);
+    } catch (AuthException $ae) {
+      return $response->json(['error' => $ae->getMessage()], Response::HTTP_UNAUTHORIZED);
     } catch (\Exception $e) {
-
-      return $response->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
+      return $response->json(['error' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/Services/InventoryUpdateService.php
+++ b/src/Services/InventoryUpdateService.php
@@ -439,8 +439,8 @@ class InventoryUpdateService
     $info = [
       'full' => (string) $fullInventory,
       'exceptionType' => get_class($exception),
-      'errorMessage' => $e->getMessage(),
-      'stackTrace' => $e->getTraceAsString()
+      'errorMessage' => $exception->getMessage(),
+      'stackTrace' => $exception->getTraceAsString()
     ];
 
     $this->logger->error(TranslationHelper::getLoggerKey(self::LOG_KEY_FAILED), [


### PR DESCRIPTION
- When AuthException is caught during Inventory Sync, return an 401 (unauthorized) because the plugin is not authorized to work with Wayfair (yet). (Was previously a 400).
- Return an HTTP 500 when a non-Auth issue occurs during Inventory Sync (was previously a 400).