### PR TITLE
round floating point stock amount DOWN to nearest integer

### DIFF
--- a/src/Mappers/InventoryMapper.php
+++ b/src/Mappers/InventoryMapper.php
@@ -81,7 +81,7 @@ class InventoryMapper
 
   /**
    * Determine the "Quantity On Hand" to report to Wayfair
-   * @param int $netStock
+   * @param float $netStock
    *
    * @return int|mixed
    */

--- a/src/Mappers/InventoryMapper.php
+++ b/src/Mappers/InventoryMapper.php
@@ -99,7 +99,9 @@ class InventoryMapper
       return -1;
     }
 
-    return $netStock;
+    // wayfair stock should be rounded DOWN to nearest integer.
+    // plenty allows for floats in net stock.
+    return floor($netStock);
   }
 
   /**
@@ -184,6 +186,7 @@ class InventoryMapper
       }
     }
 
+
     $stockRepository= pluginApp(StockRepositoryContract::class);
     $stockRepository->setFilters($filters);
 
@@ -231,7 +234,7 @@ class InventoryMapper
           continue;
         }
 
-        // Avl Immediately. ADJUSTED Net Stock (see Stock Buffer setting in Wayfair plugin).
+        // Avl Immediately.
         $originalStockNet = $stock[InventoryMapper::STOCK_COL_STOCK_NET];
         $onHand = self::normalizeQuantityOnHand($originalStockNet);
 

--- a/tests/php/Mappers/InventoryMapperTest.php
+++ b/tests/php/Mappers/InventoryMapperTest.php
@@ -359,6 +359,17 @@ final class InventoryMapperTest extends \PHPUnit\Framework\TestCase
             ["zero stock should make zero quantityOnHand", 0, 0],
             ["one stock should make 1 quantityOnHand", 1, 1],
             ["five stock should make five quantityOnHand", 5, 5],
+            ["floating point stock less than negative one should make negative 1 quantityOnHand v1", -1, -1.5],
+            ["floating point stock less than negative one should make negative 1 quantityOnHand v2", -1, -5.3],
+            ["floating point stock between zero and negative one should make negative 1 quantityOnHand v1", -1, -0.5],
+            ["floating point stock between zero and negative one should make negative 1 quantityOnHand v2", -1, -0.2],
+            ["floating point stock between zero and negative one should make negative 1 quantityOnHand v3", -1, -0.8],
+            ["floating point stock between zero and positive one should make zero quantityOnHand v1", 0, 0.2],
+            ["floating point stock between zero and positive one should make zero quantityOnHand v2", 0, 0.5],
+            ["floating point stock between zero and positive one should make zero quantityOnHand v3", 0, 0.8],
+            ["floating point stock that is positive should be rounded down v1", 1, 1.2],
+            ["floating point stock that is positive should be rounded down v2", 5, 5.5],
+            ["floating point stock that is positive should be rounded down v3", 8, 8.8],
         ];
     }
 


### PR DESCRIPTION
Plentymarkets may report a non-integer amount for stock.
This PR rounds the `netStock` in a Warehouse **down** to the nearest integer.

Needs @mcloughlin77 to look at this from a Wayfair Inventory standpoint before we can proceed.