### PR TITLE
prevention and recovery for stuck inventory sync 

### DIFF
--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -10,30 +10,20 @@ on:
 
 jobs:
   build-and-test-php:
-    # ubuntu 16.04 has PHP 7.0 installed by default.
+    # ubuntu 16.04 has PHP 7.0 installed, but it is NOT selected anymore (December 2020).
     # Plenty plugin code must be PHP 7.0 only.
     # other OSes / ubuntu versions will not be compatible.
     runs-on: ubuntu-16.04
 
     steps:
 
-      - name: output php version
-        run: php --version
-
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+      - name: switch to php 7.0
+        run: sudo update-alternatives --set php /usr/bin/php7.0
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-16.04
 
     steps:
+
+      - name: output php version
+        run: php --version
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/src/Core/Api/Services/LogSenderService.php
+++ b/src/Core/Api/Services/LogSenderService.php
@@ -39,6 +39,12 @@ class LogSenderService {
   }
 
   public function execute(array $logs) {
+
+    if (!isset($logs) || empty($logs))
+    {
+      return;
+    }
+
     /** @var LoggerContract $loggerContract */
     $loggerContract = pluginApp(LoggerContract::class);
 

--- a/src/Core/Contracts/LoggerContract.php
+++ b/src/Core/Contracts/LoggerContract.php
@@ -10,32 +10,32 @@ interface LoggerContract {
   /**
    * Detailed debug information.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function debug(string $code, $loggingInfo = null);
 
   /**
    * Logs info.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function info(string $code, $loggingInfo = null);
 
   /**
    * Errors that should be logged and monitored.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function error(string $code, $loggingInfo = null);
 
   /**
    * Warnings that should be logged and monitored.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function warning(string $code, $loggingInfo = null);
 

--- a/src/Cron/FullInventorySyncCron.php
+++ b/src/Cron/FullInventorySyncCron.php
@@ -21,4 +21,15 @@ class FullInventorySyncCron extends InventorySyncCron
   ) {
     parent::__construct(true, $inventoryUpdateService, $loggerContract);
   }
+
+
+  /**
+   * @throws \Exception
+   *
+   * @return void
+   */
+  public function handle()
+  {
+    parent::handle();
+  }
 }

--- a/src/Cron/FullInventorySyncCron.php
+++ b/src/Cron/FullInventorySyncCron.php
@@ -32,7 +32,7 @@ class FullInventorySyncCron extends InventorySyncCron
    */
   public function handle()
   {
-    $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronStartedMessage'), [
+    $this->loggerContract->info(TranslationHelper::getLoggerKey('cronStartedMessage'), [
       'additionalInfo' => [
         'full' => $this->fullInventory
       ],
@@ -42,7 +42,7 @@ class FullInventorySyncCron extends InventorySyncCron
     try {
       parent::handle();
     } finally {
-      $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronFinishedMessage'), [
+      $this->loggerContract->info(TranslationHelper::getLoggerKey('cronFinishedMessage'), [
         'additionalInfo' => [
         ],
         'method' => __METHOD__

--- a/src/Cron/FullInventorySyncCron.php
+++ b/src/Cron/FullInventorySyncCron.php
@@ -22,7 +22,6 @@ class FullInventorySyncCron extends InventorySyncCron
     parent::__construct(true, $inventoryUpdateService, $loggerContract);
   }
 
-
   /**
    * @throws \Exception
    *

--- a/src/Cron/FullInventorySyncCron.php
+++ b/src/Cron/FullInventorySyncCron.php
@@ -7,6 +7,7 @@
 namespace Wayfair\Cron;
 
 use Wayfair\Core\Contracts\LoggerContract;
+use Wayfair\Helpers\TranslationHelper;
 use Wayfair\Services\InventoryUpdateService;
 
 class FullInventorySyncCron extends InventorySyncCron
@@ -23,12 +24,29 @@ class FullInventorySyncCron extends InventorySyncCron
   }
 
   /**
+   * Call parent's handler,
+   * but create log entries with this class name for filtering
    * @throws \Exception
    *
    * @return void
    */
   public function handle()
   {
-    parent::handle();
+    $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronStartedMessage'), [
+      'additionalInfo' => [
+        'full' => $this->fullInventory
+      ],
+      'method' => __METHOD__
+    ]);
+
+    try {
+      parent::handle();
+    } finally {
+      $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronFinishedMessage'), [
+        'additionalInfo' => [
+        ],
+        'method' => __METHOD__
+      ]);
+    }
   }
 }

--- a/src/Cron/InventorySyncCron.php
+++ b/src/Cron/InventorySyncCron.php
@@ -46,7 +46,7 @@ class InventorySyncCron extends Cron
    */
   public function handle()
   {
-    $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronStartedMessage'), [
+    $this->loggerContract->info(TranslationHelper::getLoggerKey('cronStartedMessage'), [
       'additionalInfo' => [
         'full' => $this->fullInventory
       ],
@@ -63,7 +63,7 @@ class InventorySyncCron extends Cron
         'method' => __METHOD__
       ]);
     } finally {
-      $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronFinishedMessage'), [
+      $this->loggerContract->info(TranslationHelper::getLoggerKey('cronFinishedMessage'), [
         'additionalInfo' => [
           'full' => $this->fullInventory,
           'result' => $syncResult

--- a/src/Cron/OrderAcceptCron.php
+++ b/src/Cron/OrderAcceptCron.php
@@ -51,14 +51,14 @@ class OrderAcceptCron extends Cron
      * @var LoggerContract $loggerContract
      */
     $loggerContract = pluginApp(LoggerContract::class);
-    $loggerContract->debug(TranslationHelper::getLoggerKey('cronStartedMessage'), ['method' => __METHOD__]);
+    $loggerContract->info(TranslationHelper::getLoggerKey('cronStartedMessage'), ['method' => __METHOD__]);
     try {
       $this->orderService->accept($externalLogs, 1);
     } finally {
       if (count($externalLogs->getLogs())) {
         $this->logSenderService->execute($externalLogs->getLogs());
       }
-      $loggerContract->debug(TranslationHelper::getLoggerKey('cronFinishedMessage'), ['method' => __METHOD__]);
+      $loggerContract->info(TranslationHelper::getLoggerKey('cronFinishedMessage'), ['method' => __METHOD__]);
     }
   }
 }

--- a/src/Cron/OrderImportCron.php
+++ b/src/Cron/OrderImportCron.php
@@ -54,13 +54,13 @@ class OrderImportCron extends Cron
     /** @var ExternalLogs */
     $externalLogs = pluginApp(ExternalLogs::class);
     try {
-      $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronStartedMessage'), ['method' => __METHOD__]);
+      $this->loggerContract->info(TranslationHelper::getLoggerKey('cronStartedMessage'), ['method' => __METHOD__]);
       $this->orderService->process($externalLogs, 1);
     } finally {
       if (count($externalLogs->getLogs())) {
         $this->logSenderService->execute($externalLogs->getLogs());
       }
-      $this->loggerContract->debug(TranslationHelper::getLoggerKey('cronFinishedMessage'), ['method' => __METHOD__]);
+      $this->loggerContract->info(TranslationHelper::getLoggerKey('cronFinishedMessage'), ['method' => __METHOD__]);
     }
   }
 }

--- a/src/Models/InventoryUpdateResult.php
+++ b/src/Models/InventoryUpdateResult.php
@@ -21,22 +21,7 @@ class InventoryUpdateResult
     const KEY_DTOS_FAILED = 'dtosFailed';
     const KEY_ELAPSED_TIME = 'elapsedTime';
     const KEY_VARIATIONS_ATTEMPTED = 'variationsAttempted';
-
-    public function __construct(
-        bool $fullInventory = false,
-        int $dtosAttempted = 0,
-        int $variationsAttempted = 0,
-        int $dtosSaved = 0,
-        int $dtosFailed = 0,
-        int $elapsedTime = 0
-    ) {
-        $this->fullInventory = $fullInventory;
-        $this->dtosAttempted = $dtosAttempted;
-        $this->variationsAttempted = $variationsAttempted;
-        $this->dtosSaved = $dtosSaved;
-        $this->dtosFailed = $dtosFailed;
-        $this->elapsedTime = $elapsedTime;
-    }
+    const KEY_LAST_PAGE = 'lastPage';
 
     /** @var bool */
     private $fullInventory;
@@ -55,6 +40,37 @@ class InventoryUpdateResult
 
     /** @var int */
     private $elapsedTime;
+
+    /** @var int */
+    private $dataGatherMs;
+
+    /** @var int */
+    private $dataSendMs;
+
+    /** @var bool */
+    private $lastPage;
+
+    public function __construct(
+        bool $fullInventory = false,
+        int $dtosAttempted = 0,
+        int $variationsAttempted = 0,
+        int $dtosSaved = 0,
+        int $dtosFailed = 0,
+        int $elapsedTime = 0,
+        int $dataGatherMs = 0,
+        int $dataSendMs = 0,
+        bool $lastPage = false
+    ) {
+        $this->fullInventory = $fullInventory;
+        $this->dtosAttempted = $dtosAttempted;
+        $this->variationsAttempted = $variationsAttempted;
+        $this->dtosSaved = $dtosSaved;
+        $this->dtosFailed = $dtosFailed;
+        $this->elapsedTime = $elapsedTime;
+        $this->dataGatherMs = $dataGatherMs;
+        $this->dataSendMs = $dataSendMs;
+        $this->lastPage = $lastPage;
+    }
 
     public function setFullInventory(bool $fullInventory)
     {
@@ -116,6 +132,36 @@ class InventoryUpdateResult
         return $this->variationsAttempted;
     }
 
+    public function setDataGatherMs(int $dataGatherMs)
+    {
+        $this->dataGatherMs = $dataGatherMs;
+    }
+
+    public function getDataGatherMs(): int
+    {
+        return $this->dataGatherMs;
+    }
+
+    public function setDataSendMs(int $dataSendMs)
+    {
+        $this->dataSendMs = $dataSendMs;
+    }
+
+    public function getDataSendMs(): int
+    {
+        return $this->dataSendMs;
+    }
+
+    public function setLastPage(bool $lastPage)
+    {
+        $this->lastPage = $lastPage;
+    }
+
+    public function getLastPage(): bool
+    {
+        return $this->lastPage;
+    }
+
     public function toArray(): array
     {
         return [
@@ -124,7 +170,8 @@ class InventoryUpdateResult
             self::KEY_DTOS_SAVED => $this->dtosSaved,
             self::KEY_DTOS_FAILED => $this->dtosFailed,
             self::KEY_ELAPSED_TIME => $this->elapsedTime,
-            self::KEY_VARIATIONS_ATTEMPTED => $this->variationsAttempted
+            self::KEY_VARIATIONS_ATTEMPTED => $this->variationsAttempted,
+            self::KEY_LAST_PAGE => $this->lastPage
         ];
     }
 
@@ -140,6 +187,7 @@ class InventoryUpdateResult
         $this->setDtosFailed($data[self::KEY_DTOS_FAILED] ?? 0);
         $this->setElapsedTime($data[self::KEY_ELAPSED_TIME] ?? 0);
         $this->setVariationsAttempted($data[self::KEY_VARIATIONS_ATTEMPTED] ?? 0);
+        $this->setLastPage($data[self::KEY_LAST_PAGE] ?? false);
     }
 
     public function isSuccessful()

--- a/src/Repositories/WarehouseSupplierRepository.php
+++ b/src/Repositories/WarehouseSupplierRepository.php
@@ -90,7 +90,7 @@ class WarehouseSupplierRepository extends Repository
   /**
    * @param mixed $warehouseId
    *
-   * @return mixed|null
+   * @return mixed
    */
   public function findByWarehouseId($warehouseId)
   {

--- a/src/Services/InventoryStatusService.php
+++ b/src/Services/InventoryStatusService.php
@@ -164,7 +164,7 @@ class InventoryStatusService
   {
     $state = $this->keyValueRepository->get(self::DB_KEY_INVENTORY_STATUS);
 
-    if (!isset($state)) {
+    if (!isset($state) || empty($state)) {
       $state = self::STATE_IDLE;
     }
 

--- a/src/Services/InventoryStatusService.php
+++ b/src/Services/InventoryStatusService.php
@@ -456,6 +456,8 @@ class InventoryStatusService
     $startTime = $this->getStartOfMostRecentAttempt();
     $elapsedTime = time() - $startTime;
 
+    // TODO: account for an inventory sync that is stuck or has died by checking for a recent heartbeat
+
     return $elapsedTime >= $maxTime;
   }
 }

--- a/src/Services/InventoryStatusService.php
+++ b/src/Services/InventoryStatusService.php
@@ -253,7 +253,13 @@ class InventoryStatusService
   }
 
   /**
-   * Set the status back to idle state
+   * Set the status back to idle.
+   *
+   * The behavior is as such:
+   *  - status is currently unknown =  change to idle
+   *  - status is not already IDLE = do nothing
+   *  - status is not IDLE and argument matches timestamp in DB = change to idle
+   *
    * @return void
    */
   public function markInventoryIdle($syncStartTimestamp = null)
@@ -262,12 +268,12 @@ class InventoryStatusService
     $mostRecentAttempt = $this->getStartOfMostRecentAttempt();
 
     if (
-      !isset($currentStatus) || $currentStatus != self::STATE_IDLE
-      || !isset($syncStartTimestamp) || empty($syncStartTimestamp)
-      || !isset($mostRecentAttempt) || empty($mostRecentAttempt)
-      || (strtotime($syncStartTimestamp) >= strtotime($mostRecentAttempt))
+      !isset($currentStatus) || empty(trim($currentStatus)) ||
+      ($currentStatus != self::STATE_IDLE &&
+        (!isset($syncStartTimestamp) || empty(trim($syncStartTimestamp)) ||
+          !isset($mostRecentAttempt) || empty(trim($mostRecentAttempt)) ||
+          (strtotime($syncStartTimestamp) >= strtotime($mostRecentAttempt))))
     ) {
-      // only make the change if the argument does not represent an older sync than the current one
       $this->setServiceStatusValue(self::STATE_IDLE);
     }
   }

--- a/src/Services/InventoryStatusService.php
+++ b/src/Services/InventoryStatusService.php
@@ -447,14 +447,30 @@ class InventoryStatusService
   {
     $curStatus = $this->getServiceStatusValue();
 
-    if (!isset($curStatus) || empty($curStatus) || self::STATE_IDLE == $curStatus)
+    if (!isset($curStatus) || empty(trim($curStatus)) || self::STATE_IDLE == $curStatus)
     {
       return false;
     }
 
+    $startTimestamp = $this->getStartOfMostRecentAttempt();
+
+    if (!isset($startTimestamp) || empty(trim($startTimestamp)))
+    {
+      // no idea when things started so assume it's dead/done
+      return true;
+    }
+
+    $startTimeValue = strtotime($startTimestamp);
+
+    if (!$startTimestamp)
+    {
+      // start timestamp is invalid so assume it's dead/done
+      return true;
+    }
+
+    $elapsedTime = time() - $startTimeValue;
+
     $maxTime = self::FULL == $curStatus ? self::MAX_INVENTORY_RUN_TIME_FULL : self::MAX_INVENTORY_RUN_TIME_PARTIAL;
-    $startTime = $this->getStartOfMostRecentAttempt();
-    $elapsedTime = time() - $startTime;
 
     // TODO: account for an inventory sync that is stuck or has died by checking for a recent heartbeat
 

--- a/src/Services/InventoryStatusService.php
+++ b/src/Services/InventoryStatusService.php
@@ -21,7 +21,7 @@ class InventoryStatusService
   const OVERDUE_TIME_PARTIAL = 1800;
 
   // TODO: make these user-configurable in a future update
-  const MAX_INVENTORY_RUN_TIME_FULL = 21600;
+  const MAX_INVENTORY_RUN_TIME_FULL = 14400;
   const MAX_INVENTORY_RUN_TIME_PARTIAL = 3600;
 
   const LOG_KEY_STATE_CHANGE = 'inventoryStateChange';

--- a/src/Services/InventoryUpdateService.php
+++ b/src/Services/InventoryUpdateService.php
@@ -684,9 +684,7 @@ class InventoryUpdateService
       // time in result objects is in seconds
       $elapsedTime = (TimeHelper::getMilliseconds() - $unixTimeAtPageStart) * 0.001;
 
-      print('setting total variation count to: ' . $totalVariationsAttempted);
       $pageResult = $this->constructResultObject($fullInventory, $totalDtosAttempted, $totalDtosSaved, $totalDtosFailed, $elapsedTime, $totalVariationsAttempted, $dataGatherMs, $dataSendMs, $lastPage);
-      print('result object is ' . json_encode($pageResult->toArray()));
 
       $this->logger->debug(
         TranslationHelper::getLoggerKey(self::LOG_KEY_DEBUG),

--- a/src/Services/InventoryUpdateService.php
+++ b/src/Services/InventoryUpdateService.php
@@ -166,8 +166,7 @@ class InventoryUpdateService
         // stock buffer should be the same across all pages of inventory
         $stockBuffer = $this->getNormalizedStockBuffer();
 
-        // The Plentymarkets team instructed to start on page 1, not page 0.
-        $pageNumber = 1;
+
 
         $this->logger->info(TranslationHelper::getLoggerKey(self::LOG_KEY_START), [
           'additionalInfo' => [
@@ -212,7 +211,10 @@ class InventoryUpdateService
       }
 
       // setup is complete. Begin loop over Variations.
-      do {
+
+      // The Plentymarkets team instructed to start on page 1, not page 0.
+       // TODO: consider introducing maximum page number?
+      for ($pageNumber = 1; !$completedLastPage; $pageNumber++) {
         $pageResult = $this->syncNextPageOfVariations(
           $pageNumber,
           $fullInventory,
@@ -234,9 +236,7 @@ class InventoryUpdateService
         $completedLastPage = $pageResult->getLastPage();
 
         // TODO: add a heartbeat so other requestors can track the status of this one
-
-        // TODO: consider introducing maximum page number?
-      } while (!$completedLastPage);
+      }
 
       $elapsedTime = $this->calculateTimeSinceSyncStart($syncStartTimeStamp);
 

--- a/src/Services/InventoryUpdateService.php
+++ b/src/Services/InventoryUpdateService.php
@@ -589,7 +589,6 @@ class InventoryUpdateService
 
         /** @var array $variationData information about a single Variation */
         foreach ($searchResults as $variationData) {
-          print("seeing variation");
           ++$totalVariationsAttempted;
 
           /** @var RequestDTO[] */

--- a/src/Services/InventoryUpdateService.php
+++ b/src/Services/InventoryUpdateService.php
@@ -110,6 +110,7 @@ class InventoryUpdateService
     $windowStart = null;
     $windowEnd = null;
 
+    /** @var ExternalLogs */
     $externalLogs = pluginApp(ExternalLogs::class);
 
     try {
@@ -139,7 +140,10 @@ class InventoryUpdateService
           'method' => __METHOD__
         ]);
 
-        $externalLogs->addErrorLog('Inventory ' . ($fullInventory ? 'Full' : '') . ' overriding a currently running inventory sync process.');
+        $externalLogs->addWarningLog('Inventory ' . ($fullInventory ? 'Full' : '') . ' overriding a currently running inventory sync process.');
+
+        // cancel the stale/stalled run now, in case a new one does not start for some reason.
+        $this->statusService->markInventoryIdle();
       }
 
       if (!$fullInventory) {

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -51,8 +51,8 @@ class LoggingService implements LoggerContract
   /**
    * Detailed debug information.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function debug(string $code, $loggingInfo = null)
   {
@@ -64,8 +64,8 @@ class LoggingService implements LoggerContract
   /**
    * Logs info.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function info(string $code, $loggingInfo = null)
   {
@@ -77,8 +77,8 @@ class LoggingService implements LoggerContract
   /**
    * Errors that should be logged and monitored.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function error(string $code, $loggingInfo = null)
   {
@@ -89,8 +89,8 @@ class LoggingService implements LoggerContract
   /**
    * Warnings that should be logged and monitored.
    *
-   * @param string $code
-   * @param null   $loggingInfo
+   * @param string      $code
+   * @param array|null  $loggingInfo
    */
   public function warning(string $code, $loggingInfo = null)
   {
@@ -128,6 +128,11 @@ class LoggingService implements LoggerContract
    */
   public function extractVars($loggingInfo): array
   {
+    if (!isset($loggingInfo) || empty($loggingInfo))
+    {
+      return [];
+    }
+
     /** @var ExternalLogs */
     $externalLogs = pluginApp(ExternalLogs::class);
     $clientID = $this->configHelper->getClientId();

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -145,9 +145,6 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
     /**
      * Test Inventory Sync
      *
-     * // FIXME: this should not call the real syncNextPageOfVariations.
-     * // TODO: create a separate set of test cases for syncNextPageOfVariations
-     *
      * @return void
      *
      * @dataProvider dataProviderForTestSync

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -33,20 +33,22 @@ require_once(dirname(__DIR__) . DIRECTORY_SEPARATOR
 require_once(dirname(__DIR__) . DIRECTORY_SEPARATOR
     . 'lib' . DIRECTORY_SEPARATOR  . 'TestTimeException.php');
 
+use InvalidArgumentException;
 use Plenty\Modules\Item\Variation\Contracts\VariationSearchRepositoryContract;
 use Wayfair\Core\Api\Services\InventoryService;
 use Wayfair\Core\Api\Services\LogSenderService;
+use Wayfair\Core\Dto\Inventory\RequestDTO;
+use Wayfair\Core\Dto\Inventory\ResponseDTO;
+use Wayfair\Core\Exceptions\InventoryException;
 use Wayfair\Core\Exceptions\InventorySyncInProgressException;
 use Wayfair\Core\Exceptions\InventorySyncBlockedException;
 use Wayfair\Core\Exceptions\InventorySyncInterruptedException;
 use Wayfair\Core\Exceptions\NoReferencePointForPartialInventorySyncException;
 use Wayfair\Core\Helpers\AbstractConfigHelper;
-use Wayfair\Helpers\ConfigHelper;
 use Wayfair\Mappers\InventoryMapper;
 use Wayfair\Models\ExternalLogs;
 use Wayfair\Models\InventoryUpdateResult;
 use Wayfair\PlentyMockets\Factories\MockPaginatedResultFactory;
-use Wayfair\PlentyMockets\Factories\MockVariationSearchRepositoryFactory;
 use Wayfair\PlentyMockets\Factories\VariationDataFactory;
 use Wayfair\PlentyMockets\Helpers\MockPluginApp;
 use Wayfair\Services\InventoryStatusService;
@@ -89,7 +91,7 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $this->externalLogs = $this->createMock(ExternalLogs::class);
         $mockPluginApp->willReturn(ExternalLogs::class, [], $this->externalLogs);
 
-        // $mockPluginApp->willReturn(InventoryUpdateResult::class, [], new InventoryUpdateResult());
+        $mockPluginApp->willReturn(InventoryUpdateResult::class, [], new InventoryUpdateResult());
     }
 
     /**
@@ -248,8 +250,6 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
 
         $inventoryUpdateService->expects($this->exactly($expectedWindowEndCalculations))->method('getEndOfDeltaSyncWindow')->willReturn(self::TIMESTAMP_NOW);
 
-        $mockPluginApp->willReturn(InventoryUpdateResult::class, [], new InventoryUpdateResult());
-
         $inventoryUpdateService->expects($this->exactly($expectedTimeCalculations))->method('calculateTimeSinceSyncStart')->willReturn(self::ELAPSED_TIME);
 
         $expectedDtosAttempted = 0;
@@ -360,7 +360,7 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $cases[] = ["multiple page partial sync", true, true, null, false, InventoryStatusService::STATE_IDLE, self::TIMESTAMP_RECENT, self::TIMESTAMP_OVERDUE, [new InventoryUpdateResult(false, 10, 9, 10, 0, 6, 5, 4, false), new InventoryUpdateResult(false, 8, 7, 8, 0, 1, 2, 3, false), new InventoryUpdateResult(false, 7, 6, 7, 0, 5, 2, 3, true)]];
 
         // can only mock an Exception on first page for now.
-        $cases[] = ["full sync should rethrow Exception from syncing page", true, false, TestTimeException::class, true, InventoryStatusService::PARTIAL, self::TIMESTAMP_RECENT, null, [], $syncPageException];
+        $cases[] = ["full sync should wrap and rethrow arbitrary Exception from syncing page", true, false, InventoryException::class, true, InventoryStatusService::PARTIAL, self::TIMESTAMP_RECENT, null, [], $syncPageException];
 
         $cases[] = ["full sync without variations should not flag as complete", true, false, null, true, InventoryStatusService::STATE_IDLE, self::TIMESTAMP_RECENT, null, [new InventoryUpdateResult(true, 0, 0, 0, 0, 6, 5, 0, true)]];
         $cases[] = ["full sync without stocks should not flag as complete", true, false, null, true, InventoryStatusService::STATE_IDLE, self::TIMESTAMP_RECENT, null, [new InventoryUpdateResult(true, 0, 1, 0, 0, 6, 5, 0, true)]];
@@ -391,9 +391,10 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         array $cannedResponseDtosForPage = [],
         $allItemsActive = false,
         bool $lastPage = false,
-        int $pageNumber = 1
+        int $pageNumber = 1,
+        $exceptionThrownByDTOCreation = null,
+        $exceptionThrownByDTOSend = null
     ) {
-
         global $mockPluginApp;
 
         if (isset($expectedExceptionClass) && !empty($expectedExceptionClass)) {
@@ -403,7 +404,7 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         /** @var VariationSearchRepositoryContract&\PHPUnit\Framework\MockObject\MockObject */
         $variationSearchRepository = $this->createMock(VariationSearchRepositoryContract::class);
 
-        $searchesExpected = $expectedExceptionClass == InventorySyncInterruptedException::class ? 0: 1;
+        $searchesExpected = $pageNumber < 1 || $expectedExceptionClass == InventorySyncInterruptedException::class ? 0 : 1;
 
         $numVariations = count($variationDataArraysForPage);
 
@@ -419,31 +420,43 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
 
         $variationSearchRepository->expects($this->exactly($searchesExpected))->method('setSearchParams')->with($expectedSearchParams);
 
-        $amtVariations = count($variationDataArraysForPage);
-        $pageFactory = new MockPaginatedResultFactory($this, $amtVariations);
+        $pageFactory = new MockPaginatedResultFactory($this, $numVariations);
         $variationSearchRepository->expects($this->exactly($searchesExpected))->method('search')->willReturn($pageFactory->createNext($variationDataArraysForPage, $lastPage));
 
         $mockPluginApp->willReturn(VariationSearchRepositoryContract::class, [], $variationSearchRepository);
 
         $totalAmountOfRequestDTOs = 0;
-        foreach($cannedRequestDtoArraysForVariations as $resultArray)
-        {
+        foreach ($cannedRequestDtoArraysForVariations as $resultArray) {
             $totalAmountOfRequestDTOs += count($resultArray);
         }
 
         /** @var InventoryMapper&\PHPUnit\Framework\MockObject\MockObject */
         $inventoryMapper = $this->createMock(InventoryMapper::class);
-        $inventoryMapper->expects($this->exactly($numVariations))->method('createInventoryDTOsFromVariation')->willReturnOnConsecutiveCalls(...$cannedRequestDtoArraysForVariations);
+
+        $creationInvocation = $inventoryMapper->expects($this->exactly($numVariations))->method('createInventoryDTOsFromVariation');
+        if (isset($exceptionThrownByDTOCreation)) {
+            $creationInvocation->willThrowException($exceptionThrownByDTOCreation);
+        } else {
+            $creationInvocation->willReturnOnConsecutiveCalls(...$cannedRequestDtoArraysForVariations);
+        }
 
         $numRequestDtos = count($cannedRequestDtoArraysForVariations);
         /** @var InventoryService&\PHPUnit\Framework\MockObject\MockObject */
         $inventoryService = $this->createMock(InventoryService::class);
-        $inventoryService->expects($this->exactly($numRequestDtos))->method('updateBulk')->willReturn($cannedResponseDtosForPage);
+
+        $sendInvocation = $inventoryService->expects($this->exactly($numRequestDtos))->method('updateBulk');
+        if (isset($exceptionThrownByDTOSend)) {
+            $sendInvocation->willThrowException($exceptionThrownByDTOSend);
+        } else {
+            $sendInvocation->willReturnOnConsecutiveCalls(...$cannedResponseDtosForPage);
+        }
 
         /** @var InventoryStatusService&\PHPUnit\Framework\MockObject\MockObject */
         $inventoryStatusService = $this->createMock(InventoryStatusService::class);
-        $inventoryStatusService->expects($this->once())->method('getServiceStatusValue')->willReturn($statusInDatabase);
-        $inventoryStatusService->expects($this->once())->method('getStartOfMostRecentAttempt')->willReturn($mostRecentAttemptTime);
+
+        $expectedStatusChecks = $pageNumber < 1 ? 0 : 1;
+        $inventoryStatusService->expects($this->exactly($expectedStatusChecks))->method('getServiceStatusValue')->willReturn($statusInDatabase);
+        $inventoryStatusService->expects($this->exactly($expectedStatusChecks))->method('getStartOfMostRecentAttempt')->willReturn($mostRecentAttemptTime);
 
         $configHelper = $this->createConfigHelper($allItemsActive);
 
@@ -478,28 +491,35 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         if (!isset($expectedExceptionClass) || empty(trim($expectedExceptionClass))) {
             $this->assertNotNull($actualResult);
 
-            $this->assertEquals($lastPage, $actualResult->getLastPage(), "last page flag should match expectation");
+            $this->assertEquals($lastPage || !isset($variationDataArraysForPage) || empty($variationDataArraysForPage), $actualResult->getLastPage(), "last page flag should match expectation");
 
-            $this->assertEquals($amtVariations, $actualResult->getVariationsAttempted(), "amount of variations seen should match the input");
+            $this->assertEquals($numVariations, $actualResult->getVariationsAttempted(), "amount of variations seen should match the input");
 
-            // TODO: make test cases where DTO gathering fails
-            $this->assertEquals($totalAmountOfRequestDTOs, $actualResult->getDtosAttempted(), "amount of DTOs seen should match input");
+            $expectedDTOCreationAmount = 0;
+            if (!isset($exceptionThrownByDTOCreation)) {
+                $expectedDTOCreationAmount = $totalAmountOfRequestDTOs;
+            }
 
-            // TODO: make test cases where DTO sending fails
-            $this->assertEquals(count($cannedResponseDtosForPage), $actualResult->getDtosSaved(), "amount of DTOs sent should match input");
+            $this->assertEquals($expectedDTOCreationAmount, $actualResult->getDtosAttempted(), "amount of DTOs seen should match input");
+
+            $expectedSaveAmount = 0;
+            if (!isset($exceptionThrownByDTOCreation) && !isset($exceptionThrownByDTOSend)) {
+                $expectedSaveAmount = count($cannedResponseDtosForPage);
+            }
+
+            $this->assertEquals($expectedSaveAmount, $actualResult->getDtosSaved(), "amount of DTOs sent should match input");
 
             // elapsed time is in seconds, so it is often zero!
             // $this->assertGreaterThan(0, $actualResult->getElapsedTime(), "Page sync should have spent some time doing work");
 
-            // TODO: make this conditional if there are Exceptions, etc. that will prevent data gathering
-            if ($amtVariations > 0) {
+            if ($numVariations > 0 && !isset($exceptionThrownByDTOCreation)) {
                 $this->assertGreaterThan(0, $actualResult->getDataGatherMs(), "Page sync should have spent time gathering data");
-            }
 
-            if ($totalAmountOfRequestDTOs) {
-                $this->assertGreaterThan(0, $actualResult->getDataSendMs(), "Page sync should have spent some time sending data");
-            } else {
-                $this->assertEquals(0, $actualResult->getDataSendMs(), "Page sync should NOT have spent any time sending data");
+                if ($totalAmountOfRequestDTOs && !isset($exceptionThrownByDTOSend)) {
+                    $this->assertGreaterThan(0, $actualResult->getDataSendMs(), "Page sync should have spent some time sending data");
+                } else {
+                    $this->assertEquals(0, $actualResult->getDataSendMs(), "Page sync should NOT have spent any time sending data");
+                }
             }
         } else {
             $this->assertNull($actualResult);
@@ -535,31 +555,29 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $cases[] = ["full sync overridden by partial sync", InventorySyncInterruptedException::class, true, InventoryStatusService::PARTIAL, self::TIMESTAMP_FUTURE];
         $cases[] = ["full sync overridden by full sync", InventorySyncInterruptedException::class, true, InventoryStatusService::FULL, self::TIMESTAMP_FUTURE];
 
+        $cases[] = ["page number 0 invalid - partial", InvalidArgumentException::class, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, [], [], [], false, false, 0];
+        $cases[] = ["page number 0 invalid - full", InvalidArgumentException::class, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, [], [], [], false, false, 0];
+
+        $cases[] = ["page number -1 invalid - partial", InvalidArgumentException::class, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, [], [], [], false, false, -1];
+        $cases[] = ["page number -1 invalid - full", InvalidArgumentException::class, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, [], [], [], false, false, -1];
+
+        $cases[] = ["page number -5 invalid - partial", InvalidArgumentException::class, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, [], [], [], false, false, -5];
+        $cases[] = ["page number -5 invalid - full", InvalidArgumentException::class, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, [], [], [], false, false, -5];
+
+        $cases[] = ["exception thrown at data gather - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [], [], false, false, 1, new TestTimeException("DTO gather failure")];
+        $cases[] = ["exception thrown at data gather - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [], [], false, false, 1, new TestTimeException("DTO gather failure")];
+
+        $cases[] = ["exception thrown at data send - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
+        $cases[] = ["exception thrown at data send - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
+
         // TODO: positive amounts of Variations combined with various results from InventoryMapper->createInventoryDTOsFromVariation
 
         // TODO: positive amounts of Variations, positive results from InventoryMapper->createInventoryDTOsFromVariation, various results from InventoryService->updateBulk
 
+        // TODO: multiple variations - logic currently halts on first Exception, but it should go on to the next Variation!
+        // TODO: multiple Request DTOs per variation - logic currently halts on first Exception, but it should try to send next DTO!
+
         return $cases;
-    }
-
-    private function createInventoryMapper(array $cannedRequestDtoCollections, int $numVariations): InventoryMapper
-    {
-        /** @var InventoryMapper&\PHPUnit\Framework\MockObject\MockObject */
-        $inventoryMapper = $this->createPartialMock(InventoryMapper::class, ['createInventoryDTOsFromVariation']);
-
-        $inventoryMapper->expects($this->exactly($numVariations))->method('createInventoryDTOsFromVariation')->willReturnOnConsecutiveCalls(...$cannedRequestDtoCollections);
-
-        return $inventoryMapper;
-    }
-
-    private function createInventoryService(array $cannedResponseDtos): InventoryService
-    {
-        /** @var InventoryService&\PHPUnit\Framework\MockObject\MockObject */
-        $inventoryService = $this->createMock(InventoryService::class);
-        // one responseDTO per page
-        $inventoryService->method('updateBulk')->willReturnOnConsecutiveCalls(...$cannedResponseDtos);
-
-        return $inventoryService;
     }
 
     private function createConfigHelper($allItemsActive = false): AbstractConfigHelper

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -570,14 +570,11 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $cases[] = ["exception thrown at data send - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
         $cases[] = ["exception thrown at data send - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
 
-        // TODO: errors after sending data
+        // TODO: accounting for errors in ResponseDTOs after sending data
 
-        // TODO: positive amounts of Variations combined with various results from InventoryMapper->createInventoryDTOsFromVariation
+        // TODO: positive (more than 1) amounts of Variations combined with various results from InventoryMapper->createInventoryDTOsFromVariation
 
-        // TODO: positive amounts of Variations, positive results from InventoryMapper->createInventoryDTOsFromVariation, various results from InventoryService->updateBulk
-
-        // TODO: multiple variations - logic currently halts on first Exception, but it should go on to the next Variation!
-        // TODO: multiple Request DTOs per variation - logic currently halts on first Exception, but it should try to send next DTO!
+        // TODO: positive (more than 1) amounts of Variations, positive results from InventoryMapper->createInventoryDTOsFromVariation, various results from InventoryService->updateBulk
 
         return $cases;
     }

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -371,7 +371,6 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $configHelper->method('getOrderReferrerValue')->willReturn(self::REFERRER_ID);
         $configHelper->method('isAllItemsActive')->willReturn($allItemsActive);
 
-        /** @var LoggerContract&\PHPUnit\Framework\MockObject\MockObject */
         $logger = new TestTimeLogger();
 
         /** @var LogSenderService&\PHPUnit\Framework\MockObject\MockObject */

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -570,6 +570,8 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $cases[] = ["exception thrown at data send - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
         $cases[] = ["exception thrown at data send - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [[new RequestDTO()]], [], false, false, 1, null, new TestTimeException("DTO send failure")];
 
+        // TODO: errors after sending data
+
         // TODO: positive amounts of Variations combined with various results from InventoryMapper->createInventoryDTOsFromVariation
 
         // TODO: positive amounts of Variations, positive results from InventoryMapper->createInventoryDTOsFromVariation, various results from InventoryService->updateBulk

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -256,8 +256,6 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
 
         $cases[] = ["full sync with no request DTOs", $emptyResultFull, null, true, [[]], [], [$collectionOneVariation], self::TIMESTAMP_RECENT, self::TIMESTAMP_RECENT, InventoryStatusService::PARTIAL, false, self::TIMESTAMP_RECENT];
 
-        $cases[] = ["full syncs can start when the first full sync has been running for too long", $emptyResultFull, null, true, [], [], [], null, null, InventoryStatusService::FULL, false, self::TIMESTAMP_RECENT];
-
         // TODO: make sure sync method returns all DTOs that InventoryService returns to it
 
         // TODO: make sure sync method returns correct summation of failures
@@ -284,8 +282,8 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
 
         $inventoryStatusService->method('getStartOfMostRecentAttempt')->willReturn($mostRecentAttemptTime);
 
-        $overDue = $mostRecentAttemptTime == self::TIMESTAMP_OVERDUE;
-        $overLimit = $overDue && isset($currentInventoryStatus) && '' != $currentInventoryStatus &&  InventoryStatusService::STATE_IDLE != $currentInventoryStatus;
+        $overDue = strtotime($mostRecentAttemptTime) <= strtotime(self::TIMESTAMP_OVERDUE);
+        $overLimit = $overDue && isset($currentInventoryStatus) && '' != $currentInventoryStatus && InventoryStatusService::STATE_IDLE != $currentInventoryStatus;
         $inventoryStatusService->method('isOverdue')->willReturn($overDue);
         $inventoryStatusService->method('hasGoneOverTimeLimit')->willReturn($overLimit);
         $inventoryStatusService->method('markInventoryStarted')->willReturn(self::TIMESTAMP_NOW);

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -537,11 +537,6 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
             $collectionFiveVariations[] = $variationDataFactory->create(1, [12345]);
         }
 
-        $collectionFiveHundredVariations = [];
-        for ($i = 0; $i < 500; $i++) {
-            $collectionFiveHundredVariations[] = $variationDataFactory->create(1, [12345]);
-        }
-
         $cases = [];
 
         $cases[] = ["no variations - partial - not last", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW];

--- a/tests/php/Services/InventoryUpdateServiceTest.php
+++ b/tests/php/Services/InventoryUpdateServiceTest.php
@@ -606,6 +606,9 @@ final class InventoryUpdateServiceTest extends \PHPUnit\Framework\TestCase
         $cases[] = ["errors from send - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [[$emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO]], 4, false, false, 1, null, null];
         $cases[] = ["errors from send - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [[$emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO, $emptyRequestDTO]], 4, false, false, 1, null, null];
 
+        $cases[] = ["last page - partial", null, false, InventoryStatusService::PARTIAL, self::TIMESTAMP_NOW, $collectionOneVariation, [[$emptyRequestDTO]], 0, false, true, 3, null, null];
+        $cases[] = ["last page - full", null, true, InventoryStatusService::FULL, self::TIMESTAMP_NOW, $collectionOneVariation, [[$emptyRequestDTO]], 0, false, true, 3, null, null];
+
         return $cases;
     }
 

--- a/tests/php/lib/TestTimeLogger.php
+++ b/tests/php/lib/TestTimeLogger.php
@@ -10,24 +10,44 @@ use Wayfair\Core\Contracts\LoggerContract;
 
 class TestTimeLogger implements LoggerContract
 {
+    private $enableDebug;
+    private $enableInfo;
+    private $enableWarning;
+    private $enableError;
+
+    public function __construct($enableError = true, $enableWarning = true, $enableInfo = false, $enableDebug = false)
+    {
+        $this->enableError = $enableError;
+        $this->enableWarning = $enableWarning;
+        $this->enableInfo = $enableInfo;
+        $this->enableDebug = $enableDebug;
+    }
 
     public function debug(string $code, $loggingInfo = null)
     {
-        printf("\n[DEBUG]: %s\n", $code);
+        if ($this->enableDebug) {
+            printf("\n[DEBUG]: %s\n", $code);
+        }
     }
 
     public function info(string $code, $loggingInfo = null)
     {
-        printf("\n[INFO]: %s\n", $code);
+        if ($this->enableInfo) {
+            printf("\n[INFO]: %s\n", $code);
+        }
     }
 
     public function error(string $code, $loggingInfo = null)
     {
-        printf("\n[ERROR]: %s\n", $code);
+        if ($this->enableError) {
+            printf("\n[ERROR]: %s\n", $code);
+        }
     }
 
     public function warning(string $code, $loggingInfo = null)
     {
-        printf("\n[WARNING]: %s\n", $code);
+        if ($this->enableWarning) {
+            printf("\n[WARNING]: %s\n", $code);
+        }
     }
 }

--- a/tests/php/lib/TestTimeLogger.php
+++ b/tests/php/lib/TestTimeLogger.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright 2020 Wayfair LLC - All rights reserved
+ */
+
+namespace Wayfair\Test;
+
+use Wayfair\Core\Contracts\LoggerContract;
+
+class TestTimeLogger implements LoggerContract
+{
+
+    public function debug(string $code, $loggingInfo = null)
+    {
+        printf("\n[DEBUG]: %s\n", $code);
+    }
+
+    public function info(string $code, $loggingInfo = null)
+    {
+        printf("\n[INFO]: %s\n", $code);
+    }
+
+    public function error(string $code, $loggingInfo = null)
+    {
+        printf("\n[ERROR]: %s\n", $code);
+    }
+
+    public function warning(string $code, $loggingInfo = null)
+    {
+        printf("\n[WARNING]: %s\n", $code);
+    }
+}

--- a/tests/php/lib/plentymockets/Factories/VariationDataFactory.php
+++ b/tests/php/lib/plentymockets/Factories/VariationDataFactory.php
@@ -6,6 +6,9 @@
 
 namespace Wayfair\PlentyMockets\Factories;
 
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'VariationBarcodeDataFactory.php');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'VariationSkuDataFactory.php');
+
 use Wayfair\PlentyMockets\Factories\VariationBarcodeDataFactory;
 use Wayfair\PlentyMockets\Factories\VariationSkuDataFactory;
 


### PR DESCRIPTION
Mitigating https://github.com/wayfair-contribs/plentymarkets-plugin/issues/204 where a supplier's inventory synchronization process is stuck at the first attempt to upload all inventory to Wayfair.

**This will NOT solve/mitigate all of the underlying causes of failed/stalled Inventory Syncs,** as those are by yet undiscovered issues in the Wayfair Plugin code and/or they are the result of limitations placed on the Wayfair Plugin by the Plentymarkets system.

### Fixes
- Set inventory sync state in the database to `IDLE` immediately after detecting a stale/stalled Inventory Sync, to avoid letting the stale/stalled run block any subsequent runs.
  - The partial inventory cron job that runs every 15-30 minutes will do this
  - The change in state will allow the UI to do a "manual" full sync within 1 hour of a "stall."
- Do not let a failed Inventory data creation for one product prevent inventory data creation for another product.
- Lower "maximum time for full sync" to 4 hours instead of 6 hours.

### Enhancements
- re-enable logging statements that are specific to `FullInventorySynCron` so that we can filter down to Full Inventory Syncs in Plentymarkets logs
- bump logging level for all Cron jobs to `INFO` so that we can track them without the noise of turning on `DEBUG` logs 

### Testing changes
- add test cases for "should inventory syncing start?"
- add test cases for "should inventory syncing be marked as complete?"
- add test cases for "should inventory syncing be cancelled?"
- add new `TestTimeLogger` module to allow the developer to see the logs being produced by tests
- use `TestTimeLogger` during tests for `sync` method of `InventoryUpdateService

### Code Health changes
- **move "sync page of inventory" logic to its own testable subroutine**
- fix type hints for inputs in `LoggerContract` and `LoggingService`
- add null pointer protection when parsing inputs to methods in `LoggingService`
- add missing type hint for `EnternalLogs` used in `sync` method of `InventoryUpdateService`
- add import statements to `VariationDataFactory` in the `Plentymockets` library, to fix test execution when `phpunit` is run manually