### PR TITLE
repair test scripts by enforcing use of php 7.0 and stable Plenty API definitions, don't use composer cache

### DIFF
--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -16,20 +16,14 @@ jobs:
     runs-on: ubuntu-16.04
 
     steps:
+
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+      - name: switch to php 7.0
+        run: sudo update-alternatives --set php /usr/bin/php7.0
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite

--- a/.github/workflows/php_test.yml
+++ b/.github/workflows/php_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-test-php:
-    # ubuntu 16.04 has PHP 7.0 installed by default.
+    # ubuntu 16.04 has PHP 7.0 installed, but it is NOT selected anymore (December 2020).
     # Plenty plugin code must be PHP 7.0 only.
     # other OSes / ubuntu versions will not be compatible.
     runs-on: ubuntu-16.04

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.3",
-        "plentymarkets/plugin-interface": "dev-beta7",
+        "plentymarkets/plugin-interface": "dev-stable7",
         "ext-json": "*",
         "php-di/phpdoc-reader": "^2.1"
     },


### PR DESCRIPTION
**BLOCKS ALL SUBSEQUENT PRs**

Ubuntu 16.04 image on GitHub is using PHP 8.0 by default, so the test script needs to switch the OS over to PHP 7.0 before doing any `Composer` / `PHP` actions.

The `dev-beta7` channel of the `plentymarkets/plugin-interface` package now depends on PHP 7.3, so the requirement has been updated to the `dev-stable7` channel, which is still compatible with PHP 7.0.

The Composer Cache step has been **removed**, as it was preventing us from detecting PHP/Composer issues.